### PR TITLE
[backend/fix] 500 No static resource 나오는 오류 해결

### DIFF
--- a/backend/src/main/java/km/cd/backend/common/error/CustomExceptionHandler.java
+++ b/backend/src/main/java/km/cd/backend/common/error/CustomExceptionHandler.java
@@ -9,19 +9,33 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.DelegatingAccessDeniedHandler;
 import org.springframework.security.web.authentication.DelegatingAuthenticationEntryPoint;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 /**
  * Controller 단과 Filter 단에서 발생하는 모든 Exception을 Handling 합니다.
+ *
  * @author Sukju Hong
  */
 @Slf4j
 @RestControllerAdvice
 public class CustomExceptionHandler {
 
+    @ExceptionHandler(NoHandlerFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseEntity<ErrorResponse> handle404(NoHandlerFoundException e) {
+        return ResponseEntity
+                .status(e.getStatusCode())
+                .body(ErrorResponse.builder()
+                        .status(e.getStatusCode().value())
+                        .message(e.getMessage())
+                        .build());
+    }
+
     /**
      * 인가 과정에 대한 ExceptionHandler
-     * {@link DelegatingAccessDeniedHandler}에서
+     * {@link CustomAccessDeniedHandler}에서
      * {@link org.springframework.web.servlet.HandlerExceptionResolver}에 의해 Error가 넘어옵니다.
      */
     @ExceptionHandler(AccessDeniedException.class)
@@ -37,8 +51,8 @@ public class CustomExceptionHandler {
     /**
      * 인증 과정에 대한 ExceptionHandler
      * {@link JwtTokenProvider#validateToken(String)}에서 발생한 오류가 try-catch 되어
-     * {@link jakarta.servlet.http.HttpServletRequest#setAttribute(String, Object)}로 Exception이 bingding 되고,
-     * 해당 Exception이 {@link DelegatingAuthenticationEntryPoint}에서 받아져 {@link org.springframework.web.servlet.HandlerExceptionResolver}에 의해 Error가 넘어옵니다.
+     * {@link jakarta.servlet.http.HttpServletRequest#setAttribute(String, Object)}로 Exception이 binding 되고,
+     * 해당 Exception이 {@link CustomAuthenticationEntryPoint}에서 받아져 {@link org.springframework.web.servlet.HandlerExceptionResolver}에 의해 Error가 넘어옵니다.
      */
     @ExceptionHandler(JwtTokenInvalidException.class)
     public ResponseEntity<ErrorResponse> handlerTokenNotValidateException(final JwtTokenInvalidException e) {

--- a/backend/src/main/java/km/cd/backend/common/error/CustomExceptionHandler.java
+++ b/backend/src/main/java/km/cd/backend/common/error/CustomExceptionHandler.java
@@ -6,8 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.web.access.DelegatingAccessDeniedHandler;
-import org.springframework.security.web.authentication.DelegatingAuthenticationEntryPoint;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -30,6 +30,10 @@ spring:
     ansi:
       enabled: always
 
+  web:
+    resources:
+      add-mappings: false
+
 jwt:
   secret: ${JWT_SECRET}
   ac_expiration_in_ms: ${JWT_AC_EXPIRATION_IN_MS}


### PR DESCRIPTION
## 개요 :mag:

설정되지 않은 엔드포인트에서 404 Not found 대신 500 No static resouce가 나오는 오류였습니다.

### 연관된 이슈

close #17

## 작업사항 :memo:

static resource를 비활성화 하고 NoHandlerException을 handling 했습니다.

### 스크린샷 (선택)

![image](https://github.com/kookmin-sw/capstone-2024-31/assets/102505374/434cea3d-da7a-4d6b-8c76-7d165aade807)

## 테스트 방법

없는 엔드포인트로 접속해보시면 확인해보실 수 있습니다.
