### PR TITLE
[beackend/feat] 커뮤니티 S3 연동 및 좋아요 기능 추가

### DIFF
--- a/backend/src/main/java/km/cd/backend/challenge/domain/Challenge.java
+++ b/backend/src/main/java/km/cd/backend/challenge/domain/Challenge.java
@@ -3,11 +3,8 @@ package km.cd.backend.challenge.domain;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.Date;

--- a/backend/src/main/java/km/cd/backend/challenge/dto/enums/FilePathEnum.java
+++ b/backend/src/main/java/km/cd/backend/challenge/dto/enums/FilePathEnum.java
@@ -4,7 +4,8 @@ import lombok.Getter;
 
 @Getter
 public enum FilePathEnum {
-  CHALLENGES("challenges");
+  CHALLENGES("challenges"),
+  COMMUNITY("community");
 
   private final String path;
 

--- a/backend/src/main/java/km/cd/backend/community/controller/CommentController.java
+++ b/backend/src/main/java/km/cd/backend/community/controller/CommentController.java
@@ -17,7 +17,7 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    @PostMapping("/")
+    @PostMapping("")
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<CommentResponse> createComment(
             @PathVariable(name = "postId") Long postId,

--- a/backend/src/main/java/km/cd/backend/community/controller/CommentController.java
+++ b/backend/src/main/java/km/cd/backend/community/controller/CommentController.java
@@ -11,7 +11,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/challenge/{challengeId}/posts/{postId}/comments")
+@RequestMapping("/challenge/{challengeId}/post/{postId}/comment")
 @RequiredArgsConstructor
 public class CommentController {
 

--- a/backend/src/main/java/km/cd/backend/community/controller/PostController.java
+++ b/backend/src/main/java/km/cd/backend/community/controller/PostController.java
@@ -44,7 +44,7 @@ public class PostController {
     return ResponseEntity.ok(postSimpleResponses);
   }
 
-  @GetMapping("{postId}")
+  @GetMapping("/{postId}")
   public ResponseEntity<PostDetailResponse> getPost(
           @PathVariable(name = "postId") Long postId
   ) {
@@ -52,7 +52,7 @@ public class PostController {
     return ResponseEntity.ok(postDetailResponse);
   }
 
-  @DeleteMapping("{postId}")
+  @DeleteMapping("/{postId}")
   public ResponseEntity<Void> deletePost(
           @PathVariable(name = "postId") Long postId,
           @AuthenticationPrincipal PrincipalDetails principalDetails) {

--- a/backend/src/main/java/km/cd/backend/community/controller/PostController.java
+++ b/backend/src/main/java/km/cd/backend/community/controller/PostController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -26,9 +27,10 @@ public class PostController {
   @ResponseStatus(HttpStatus.CREATED)
   public ResponseEntity<PostDetailResponse> createPost(
       @PathVariable(name = "challengeId") Long challengeId,
-      @RequestBody PostRequest postRequest,
+      @RequestPart(value = "data") PostRequest postRequest,
+      @RequestPart(value = "image") MultipartFile image,
       @AuthenticationPrincipal PrincipalDetails principalDetails) {
-    PostDetailResponse postResponse = postService.createPost(principalDetails.getUserId(), challengeId, postRequest);
+    PostDetailResponse postResponse = postService.createPost(principalDetails.getUserId(), challengeId, postRequest, image);
     return ResponseEntity
             .status(HttpStatus.CREATED)
             .body(postResponse);

--- a/backend/src/main/java/km/cd/backend/community/controller/PostController.java
+++ b/backend/src/main/java/km/cd/backend/community/controller/PostController.java
@@ -2,6 +2,7 @@ package km.cd.backend.community.controller;
 
 import km.cd.backend.community.dto.PostSimpleResponse;
 import km.cd.backend.community.dto.PostDetailResponse;
+import km.cd.backend.community.service.LikeService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,11 +18,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 @RestController
-@RequestMapping("/challenge/{challengeId}/posts")
+@RequestMapping("/challenge/{challengeId}/post")
 @RequiredArgsConstructor
 public class PostController {
 
   private final PostService postService;
+  private final LikeService likeService;
 
   @PostMapping("")
   @ResponseStatus(HttpStatus.CREATED)
@@ -57,6 +59,24 @@ public class PostController {
           @PathVariable(name = "postId") Long postId,
           @AuthenticationPrincipal PrincipalDetails principalDetails) {
     postService.deletePost(principalDetails.getUserId(), postId);
+    return ResponseEntity.ok(null);
+  }
+
+  @PostMapping("/{postId}/like")
+  public ResponseEntity<Void> likePost(
+          @AuthenticationPrincipal PrincipalDetails principalDetails,
+          @PathVariable(name = "postId") Long postId
+  ) {
+    likeService.likePost(principalDetails.getUserId(), postId);
+    return ResponseEntity.ok(null);
+  }
+
+  @DeleteMapping("/{postId}/like")
+  public ResponseEntity<Void> unlikePost(
+          @AuthenticationPrincipal PrincipalDetails principalDetails,
+          @PathVariable(name = "postId") Long postId
+  ) {
+    likeService.unlikePost(principalDetails.getUserId(), postId);
     return ResponseEntity.ok(null);
   }
 

--- a/backend/src/main/java/km/cd/backend/community/domain/Like.java
+++ b/backend/src/main/java/km/cd/backend/community/domain/Like.java
@@ -1,0 +1,27 @@
+package km.cd.backend.community.domain;
+
+import jakarta.persistence.*;
+import km.cd.backend.user.User;
+import lombok.*;
+
+@Entity
+@Table(name = "likes")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Like {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+}

--- a/backend/src/main/java/km/cd/backend/community/domain/Post.java
+++ b/backend/src/main/java/km/cd/backend/community/domain/Post.java
@@ -4,10 +4,7 @@ import jakarta.persistence.*;
 import km.cd.backend.challenge.domain.Challenge;
 import km.cd.backend.common.domain.BaseTimeEntity;
 import km.cd.backend.user.User;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +30,8 @@ public class Post extends BaseTimeEntity {
   @JoinColumn(name = "author_id")
   private User author;
 
-  private String picture;
+  @Setter
+  private String image;
 
   @OneToMany(mappedBy = "post", orphanRemoval = true)
   private List<Comment> comments = new ArrayList<>();

--- a/backend/src/main/java/km/cd/backend/community/domain/Post.java
+++ b/backend/src/main/java/km/cd/backend/community/domain/Post.java
@@ -34,7 +34,10 @@ public class Post extends BaseTimeEntity {
   private String image;
 
   @OneToMany(mappedBy = "post", orphanRemoval = true)
-  private List<Comment> comments = new ArrayList<>();
+  private final List<Comment> comments = new ArrayList<>();
+
+  @OneToMany(mappedBy = "post", orphanRemoval = true)
+  private final List<Like> likes = new ArrayList<>();
 
   @Builder
   public Post(String title, String content, Challenge challenge, User author) {

--- a/backend/src/main/java/km/cd/backend/community/dto/PostDetailResponse.java
+++ b/backend/src/main/java/km/cd/backend/community/dto/PostDetailResponse.java
@@ -10,7 +10,7 @@ public record PostDetailResponse(
         String title,
         String content,
         UserResponse author,
-        String picture,
+        String image,
         LocalDateTime createdDate,
         List<CommentResponse> comments) {
 }

--- a/backend/src/main/java/km/cd/backend/community/mapper/PostMapper.java
+++ b/backend/src/main/java/km/cd/backend/community/mapper/PostMapper.java
@@ -29,7 +29,6 @@ public interface PostMapper {
   PostDetailResponse entityToDetailResponse(Post post);
 
   @Mapping(target = "author", source = "user")
-  @Mapping(target = "challenge", source = "challenge")
   Post requestToEntity(PostRequest postRequest, User user, Challenge challenge);
 
   @Named("mapComments")

--- a/backend/src/main/java/km/cd/backend/community/repository/LikeRepository.java
+++ b/backend/src/main/java/km/cd/backend/community/repository/LikeRepository.java
@@ -1,0 +1,13 @@
+package km.cd.backend.community.repository;
+
+import km.cd.backend.community.domain.Like;
+import km.cd.backend.community.domain.Post;
+import km.cd.backend.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    Optional<Like> findByUserAndPost(User user, Post post);
+}

--- a/backend/src/main/java/km/cd/backend/community/service/LikeService.java
+++ b/backend/src/main/java/km/cd/backend/community/service/LikeService.java
@@ -1,0 +1,56 @@
+package km.cd.backend.community.service;
+
+import km.cd.backend.common.error.CustomException;
+import km.cd.backend.community.domain.Like;
+import km.cd.backend.community.domain.Post;
+import km.cd.backend.community.repository.LikeRepository;
+import km.cd.backend.community.repository.PostRepository;
+import km.cd.backend.user.User;
+import km.cd.backend.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final LikeRepository likeRepository;
+
+    @Transactional
+    public void likePost(Long userId, Long postId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(400, "User not found."));
+        Post post = postRepository.findByIdWithComment(postId)
+                .orElseThrow(() -> new CustomException(400, "Post not found."));
+
+        Optional<Like> _like = likeRepository.findByUserAndPost(user, post);
+        if (_like.isPresent()) {
+            throw new CustomException(400, "Like already exists.");
+        }
+
+        Like like = Like.builder()
+                .user(user)
+                .post(post)
+                .build();
+        likeRepository.save(like);
+    }
+
+    @Transactional
+    public void unlikePost(Long userId, Long postId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(400, "User not found."));
+        Post post = postRepository.findByIdWithComment(postId)
+                .orElseThrow(() -> new CustomException(400, "Post not found."));
+        Like like = likeRepository.findByUserAndPost(user, post)
+                .orElseThrow(() -> new CustomException(400, "Like not found."));
+
+        likeRepository.delete(like);
+    }
+
+}

--- a/backend/src/main/java/km/cd/backend/community/service/PostService.java
+++ b/backend/src/main/java/km/cd/backend/community/service/PostService.java
@@ -10,6 +10,7 @@ import km.cd.backend.community.dto.PostDetailResponse;
 import km.cd.backend.community.dto.PostRequest;
 import km.cd.backend.community.dto.PostSimpleResponse;
 import km.cd.backend.community.mapper.PostMapper;
+import km.cd.backend.community.repository.LikeRepository;
 import km.cd.backend.community.repository.PostRepository;
 import km.cd.backend.user.User;
 import km.cd.backend.user.UserRepository;
@@ -37,6 +38,10 @@ public class PostService {
 
     Challenge challenge = challengeRepository.findById(challengeId)
         .orElseThrow(() -> new CustomException(400, "Challenge not found."));
+
+    if (image.isEmpty()) {
+      throw new CustomException(400, "Image is null.");
+    }
 
     PostMapper postMapper = PostMapper.INSTANCE;
     Post post = postMapper.requestToEntity(postRequest, user, challenge);

--- a/backend/src/main/java/km/cd/backend/community/service/PostService.java
+++ b/backend/src/main/java/km/cd/backend/community/service/PostService.java
@@ -1,8 +1,10 @@
 package km.cd.backend.community.service;
 
 import km.cd.backend.challenge.domain.Challenge;
+import km.cd.backend.challenge.dto.enums.FilePathEnum;
 import km.cd.backend.challenge.repository.ChallengeRepository;
 import km.cd.backend.common.error.CustomException;
+import km.cd.backend.common.utils.S3Uploader;
 import km.cd.backend.community.domain.Post;
 import km.cd.backend.community.dto.PostDetailResponse;
 import km.cd.backend.community.dto.PostRequest;
@@ -14,6 +16,7 @@ import km.cd.backend.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -25,9 +28,10 @@ public class PostService {
   private final ChallengeRepository challengeRepository;
   private final UserRepository userRepository;
   private final PostRepository postRepository;
+  private final S3Uploader s3Uploader;
 
   @Transactional
-  public PostDetailResponse createPost(Long userId, Long challengeId, PostRequest postRequest) {
+  public PostDetailResponse createPost(Long userId, Long challengeId, PostRequest postRequest, MultipartFile image) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new CustomException(400, "User not found."));
 
@@ -36,7 +40,11 @@ public class PostService {
 
     PostMapper postMapper = PostMapper.INSTANCE;
     Post post = postMapper.requestToEntity(postRequest, user, challenge);
+
+    String imagePath = s3Uploader.uploadFileToS3(image, FilePathEnum.COMMUNITY.getPath());
+    post.setImage(imagePath);
     postRepository.save(post);
+
     return postMapper.entityToDetailResponse(post);
   }
 

--- a/backend/src/main/java/km/cd/backend/user/UserController.java
+++ b/backend/src/main/java/km/cd/backend/user/UserController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/users")
+@RequestMapping("/user")
 @RequiredArgsConstructor
 public class UserController {
 

--- a/backend/src/test/java/km/cd/backend/community/service/CommentServiceTest.java
+++ b/backend/src/test/java/km/cd/backend/community/service/CommentServiceTest.java
@@ -45,7 +45,6 @@ class CommentServiceTest {
     CommentService commentService;
 
     private User fakeUser;
-    private Challenge fakeChallenge;
     private Post fakePost;
 
     @BeforeEach
@@ -54,8 +53,7 @@ class CommentServiceTest {
                 .email("email")
                 .name("name")
                 .build();
-        fakeChallenge = Challenge.builder()
-                .build();
+        Challenge fakeChallenge = new Challenge();
         fakePost = Post.builder()
                 .title("title")
                 .content("content")

--- a/backend/src/test/java/km/cd/backend/community/service/PostServiceTest.java
+++ b/backend/src/test/java/km/cd/backend/community/service/PostServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,6 +44,11 @@ class PostServiceTest {
 
     private User fakeUser;
     private Challenge fakeChallenge;
+    private final MockMultipartFile file = new MockMultipartFile(
+            "files",
+            "imageFile.png",
+            "image/png",
+            "<<png data>>".getBytes());
 
     @BeforeEach
     void setUp() {
@@ -50,8 +56,7 @@ class PostServiceTest {
                 .email("email")
                 .name("name")
                 .build();
-        fakeChallenge = Challenge.builder()
-                .build();
+        fakeChallenge = new Challenge();
         userRepository.save(fakeUser);
         challengeRepository.save(fakeChallenge);
     }
@@ -64,7 +69,7 @@ class PostServiceTest {
                 "description"
         );
 
-        PostDetailResponse postDetailResponse = postService.createPost(fakeUser.getId(), fakeChallenge.getChallenge_id(), postRequest);
+        PostDetailResponse postDetailResponse = postService.createPost(fakeUser.getId(), fakeChallenge.getChallenge_id(), postRequest, file);
 
         assertEquals(postRequest.title(), postDetailResponse.title());
         assertEquals(postRequest.content(), postDetailResponse.content());
@@ -81,8 +86,8 @@ class PostServiceTest {
                 "title",
                 "description"
         );
-        postService.createPost(fakeUser.getId(), fakeChallenge.getChallenge_id(), postRequest1);
-        postService.createPost(fakeUser.getId(), fakeChallenge.getChallenge_id(), postRequest2);
+        postService.createPost(fakeUser.getId(), fakeChallenge.getChallenge_id(), postRequest1, file);
+        postService.createPost(fakeUser.getId(), fakeChallenge.getChallenge_id(), postRequest2, file);
 
         List<PostSimpleResponse> postSimpleResponses = postService.findAllByChallengeId(fakeChallenge.getChallenge_id());
 
@@ -103,7 +108,7 @@ class PostServiceTest {
                 "description"
         );
 
-        PostDetailResponse postDetailResponse = postService.createPost(fakeUser.getId(), fakeChallenge.getChallenge_id(), postRequest);
+        PostDetailResponse postDetailResponse = postService.createPost(fakeUser.getId(), fakeChallenge.getChallenge_id(), postRequest, file);
 
         postService.deletePost(fakeUser.getId(), postDetailResponse.id());
 


### PR DESCRIPTION
## 개요 :mag:

커뮤니티에 올라가는 사진을 S3로 연동했고, 좋아요 및 좋아요 취소 만들었습니다.

### 연관된 이슈

Closes #20

## 작업사항 :memo:

S3Uploder를 이용해 FilePathEnum에 community를 추가한뒤 업로드하였고,
Like란 다대다 테이블 구성해 유저 좋아요 기능 만들었습니다.

## 💬리뷰 요구사항(선택)

현재 S3삭제에 대해 구현은 되어있지만 사용은 하지 않는 것 같습니다.
챌린지가 삭제되거나 글이 삭제되었을때 로직을 추가해야할 것 같습니다.

추가적으로 해당 업로드 시엔 사진에 대한 인증 여부가 끝난 상태여야합니다. (추가적으로 인증 구현 안했음)
따라서 인증 과정을 추가적으로 개발해 PR 올리도록 하겠습니다.