### PR TITLE
[FE/feat] 로그인 유지 및 유저 정보 받아오기

### DIFF
--- a/backend/src/main/java/km/cd/backend/common/config/SwaggerConfig.java
+++ b/backend/src/main/java/km/cd/backend/common/config/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package km.cd.backend.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        String jwt = "JWT";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
+        Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
+            .name(jwt)
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("bearer")
+            .bearerFormat("JWT")
+        );
+        return new OpenAPI()
+            .components(new Components())
+            .info(apiInfo())
+            .addSecurityItem(securityRequirement)
+            .components(components);
+    }
+    private Info apiInfo() {
+        return new Info()
+            .title("루틴업") // API의 제목
+            .description("백엔드 API") // API에 대한 설명
+            .version("1.0.0"); // API의 버전
+    }
+}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,5 +1,12 @@
+# Do not remove or rename entries in this file, only add new ones
+# See https://github.com/flutter/flutter/issues/128635 for more context.
+
+#env
+.env
+
 # Miscellaneous
 *.class
+*.lock
 *.log
 *.pyc
 *.swp
@@ -8,7 +15,6 @@
 .buildlog/
 .history
 .svn/
-migrate_working_dir/
 
 # IntelliJ related
 *.iml
@@ -16,28 +22,127 @@ migrate_working_dir/
 *.iws
 .idea/
 
-# The .vscode folder contains launch configuration and tasks you configure in
-# VS Code which you may wish to be included in version control, so this line
-# is commented out by default.
-#.vscode/
+# Visual Studio Code related
+.classpath
+.project
+.settings/
+.vscode/*
+
+devtools_options.yaml
+
+# Flutter repo-specific
+/bin/cache/
+/bin/internal/bootstrap.bat
+/bin/internal/bootstrap.sh
+/bin/mingit/
+/dev/benchmarks/mega_gallery/
+/dev/bots/.recipe_deps
+/dev/bots/android_tools/
+/dev/devicelab/ABresults*.json
+/dev/docs/doc/
+/dev/docs/api_docs.zip
+/dev/docs/flutter.docs.zip
+/dev/docs/lib/
+/dev/docs/pubspec.yaml
+/dev/integration_tests/**/xcuserdata
+/dev/integration_tests/**/Pods
+/packages/flutter/coverage/
+version
+analysis_benchmark.json
+
+# packages file containing multi-root paths
+.packages.generated
 
 # Flutter/Dart/Pub related
 **/doc/api/
-**/ios/Flutter/.last_build_id
 .dart_tool/
 .flutter-plugins
 .flutter-plugins-dependencies
+**/generated_plugin_registrant.dart
+.packages
+.pub-preload-cache/
 .pub-cache/
 .pub/
-/build/
+build/
+flutter_*.png
+linked_*.ds
+unlinked.ds
+unlinked_spec.ds
 
-# Symbolication related
+# Android related
+**/android/**/gradle-wrapper.jar
+.gradle/
+**/android/captures/
+**/android/gradlew
+**/android/gradlew.bat
+**/android/local.properties
+**/android/**/GeneratedPluginRegistrant.java
+**/android/key.properties
+*.jks
+
+# iOS/XCode related
+**/ios/**/*.mode1v3
+**/ios/**/*.mode2v3
+**/ios/**/*.moved-aside
+**/ios/**/*.pbxuser
+**/ios/**/*.perspectivev3
+**/ios/**/*sync/
+**/ios/**/.sconsign.dblite
+**/ios/**/.tags*
+**/ios/**/.vagrant/
+**/ios/**/DerivedData/
+**/ios/**/Icon?
+**/ios/**/Pods/
+**/ios/**/.symlinks/
+**/ios/**/profile
+**/ios/**/xcuserdata
+**/ios/.generated/
+**/ios/Flutter/.last_build_id
+**/ios/Flutter/App.framework
+**/ios/Flutter/Flutter.framework
+**/ios/Flutter/Flutter.podspec
+**/ios/Flutter/Generated.xcconfig
+**/ios/Flutter/ephemeral
+**/ios/Flutter/app.flx
+**/ios/Flutter/app.zip
+**/ios/Flutter/flutter_assets/
+**/ios/Flutter/flutter_export_environment.sh
+**/ios/ServiceDefinitions.json
+**/ios/Runner/GeneratedPluginRegistrant.*
+
+# macOS
+**/Flutter/ephemeral/
+**/Pods/
+**/macos/Flutter/GeneratedPluginRegistrant.swift
+**/macos/Flutter/ephemeral
+**/xcuserdata/
+
+# Windows
+**/windows/flutter/generated_plugin_registrant.cc
+**/windows/flutter/generated_plugin_registrant.h
+**/windows/flutter/generated_plugins.cmake
+
+# Linux
+**/linux/flutter/generated_plugin_registrant.cc
+**/linux/flutter/generated_plugin_registrant.h
+**/linux/flutter/generated_plugins.cmake
+
+# Coverage
+coverage/
+
+# Symbols
 app.*.symbols
 
-# Obfuscation related
-app.*.map.json
+# Exceptions to above rules.
+!**/ios/**/default.mode1v3
+!**/ios/**/default.mode2v3
+!**/ios/**/default.pbxuser
+!**/ios/**/default.perspectivev3
+!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+!/dev/ci/**/Gemfile.lock
+!.vscode/settings.json
 
-# Android Studio will place build artifacts here
-/android/app/debug
-/android/app/profile
-/android/app/release
+# firebase
+**/lib/firebase_options.dart
+**/android/app/google-services.json
+**/ios/firebase_app_id_file.json

--- a/frontend/lib/env.dart
+++ b/frontend/lib/env.dart
@@ -1,0 +1,6 @@
+abstract class Env {
+  Env._();
+
+  static const String serverUrl = 'http://3.34.14.45:8080';
+  static const String serverUrlNip = 'http://3.34.14.45.nip.io:8080';
+}

--- a/frontend/lib/login/login_screen.dart
+++ b/frontend/lib/login/login_screen.dart
@@ -1,4 +1,4 @@
-import 'dart:math';
+import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
@@ -7,11 +7,13 @@ import 'package:frontend/model/config/palette.dart';
 import 'package:logger/logger.dart';
 import 'package:get/get.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-
-import 'package:frontend/model/data/global_variables.dart';
+import 'package:frontend/env.dart';
+import 'package:http/http.dart' as http;
+import 'package:frontend/model/controller/user_controller.dart';
+import 'package:frontend/model/data/user.dart';
 
 class LoginScreen extends StatefulWidget {
-  const LoginScreen({Key? key}) : super(key: key);
+  const LoginScreen({super.key});
 
   @override
   State<LoginScreen> createState() => _LoginScreenState();
@@ -24,13 +26,9 @@ class _LoginScreenState extends State<LoginScreen> {
   final logger = Logger();
 
   Future<void> _pressGoogleLoginButton() async {
-    // setState(() {
-    //   isPressGoogleLogin = true;
-    // });
     const callbackUrlScheme = "web-auth-callback";
 
-    final url = Uri.parse(
-        "${GlobalVariables().SERVER_URL_NIP}/oauth2/authorization/google");
+    final url = Uri.parse("${Env.serverUrlNip}/oauth2/authorization/google");
 
     final result = await FlutterWebAuth2.authenticate(
         url: url.toString(), callbackUrlScheme: callbackUrlScheme);
@@ -41,11 +39,39 @@ class _LoginScreenState extends State<LoginScreen> {
     if (accessToken != null) {
       final SharedPreferences prefs = await SharedPreferences.getInstance();
       prefs.setString("access_token", accessToken);
-
-      logger.d("saved access_token!");
     }
-    logger.d(' 구글 로그인 성공 👋');
-    Get.offAll(() => const MainScreen());
+
+    bool isLoginSuccess = await _getUserData();
+    if (isLoginSuccess) {
+      logger.d(' 구글 로그인 성공 👋');
+      Get.offAll(() => const MainScreen());
+    }
+  }
+
+  Future<bool> _getUserData() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final String? accessToken = prefs.getString('access_token');
+    const String url = '${Env.serverUrl}/users/me';
+
+    final response = await http.get(
+      Uri.parse(url),
+      headers: <String, String>{
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $accessToken',
+      },
+    );
+
+    if (response.statusCode == 200) {
+      UserController userController = Get.find<UserController>();
+      final Map<String, dynamic> data =
+          jsonDecode(utf8.decode(response.bodyBytes));
+      final User user = User.fromJson(data);
+      userController.saveUser(user);
+      return true;
+    }
+
+    Get.snackbar('로그인 실패', '다시 로그인해주세요');
+    return false;
   }
 
   @override

--- a/frontend/lib/login/login_screen.dart
+++ b/frontend/lib/login/login_screen.dart
@@ -41,37 +41,8 @@ class _LoginScreenState extends State<LoginScreen> {
       prefs.setString("access_token", accessToken);
     }
 
-    bool isLoginSuccess = await _getUserData();
-    if (isLoginSuccess) {
-      logger.d(' 구글 로그인 성공 👋');
-      Get.offAll(() => const MainScreen());
-    }
-  }
-
-  Future<bool> _getUserData() async {
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
-    final String? accessToken = prefs.getString('access_token');
-    const String url = '${Env.serverUrl}/users/me';
-
-    final response = await http.get(
-      Uri.parse(url),
-      headers: <String, String>{
-        'Content-Type': 'application/json',
-        'Authorization': 'Bearer $accessToken',
-      },
-    );
-
-    if (response.statusCode == 200) {
-      UserController userController = Get.find<UserController>();
-      final Map<String, dynamic> data =
-          jsonDecode(utf8.decode(response.bodyBytes));
-      final User user = User.fromJson(data);
-      userController.saveUser(user);
-      return true;
-    }
-
-    Get.snackbar('로그인 실패', '다시 로그인해주세요');
-    return false;
+    logger.d(' 구글 로그인 성공 👋');
+    Get.offAll(() => const MainScreen());
   }
 
   @override

--- a/frontend/lib/login/login_screen.dart
+++ b/frontend/lib/login/login_screen.dart
@@ -8,6 +8,8 @@ import 'package:logger/logger.dart';
 import 'package:get/get.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:frontend/model/data/global_variables.dart';
+
 class LoginScreen extends StatefulWidget {
   const LoginScreen({Key? key}) : super(key: key);
 
@@ -20,7 +22,6 @@ class _LoginScreenState extends State<LoginScreen> {
   bool isPressGoogleLogin = false;
   bool isSuccessGoogleLogin = false;
   final logger = Logger();
-  final API_SERVER_URL = "http://3.34.14.45.nip.io:8080";
 
   Future<void> _pressGoogleLoginButton() async {
     // setState(() {
@@ -28,7 +29,8 @@ class _LoginScreenState extends State<LoginScreen> {
     // });
     const callbackUrlScheme = "web-auth-callback";
 
-    final url = Uri.parse("$API_SERVER_URL/oauth2/authorization/google");
+    final url = Uri.parse(
+        "${GlobalVariables().SERVER_URL_NIP}/oauth2/authorization/google");
 
     final result = await FlutterWebAuth2.authenticate(
         url: url.toString(), callbackUrlScheme: callbackUrlScheme);
@@ -42,8 +44,8 @@ class _LoginScreenState extends State<LoginScreen> {
 
       logger.d("saved access_token!");
     }
-    print(' 구글 로그인 성공 👋');
-    Get.offAll(() => MainScreen());
+    logger.d(' 구글 로그인 성공 👋');
+    Get.offAll(() => const MainScreen());
   }
 
   @override

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:frontend/challenge/create/create_challenge_screen_fir.dart';
 import 'package:frontend/challenge/detail/detail_challenge_screen.dart';
 import 'package:frontend/community/tab_community_screen.dart';
 import 'package:frontend/login/login_screen.dart';
+import 'package:frontend/model/controller/user_controller.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:frontend/main/main_screen.dart';
 import 'package:logger/logger.dart';
@@ -11,12 +12,13 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:frontend/model/data/global_variables.dart';
+
 void main() async {
   WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
   await initializeDateFormatting('ko_KR', null);
 
-   
   bool isLoggedIn = await checkIfLoggedIn();
   FlutterNativeSplash.remove();
   runApp(MyApp(isLoggedIn: isLoggedIn));
@@ -32,11 +34,11 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-
   @override
   // This widgets is the root of your application.
   Widget build(BuildContext context) {
-    
+    final UserController userController = Get.put(UserController());
+
     return ScreenUtilInit(
         designSize: const Size(375, 844),
         minTextAdapt: true,
@@ -44,7 +46,7 @@ class _MyAppState extends State<MyApp> {
           return GetMaterialApp(
               theme: ThemeData(primaryColor: Colors.white),
               // navigatorObservers: <NavigatorObserver>[observer],
-              initialRoute:  widget.isLoggedIn ? 'main' : 'login',
+              initialRoute: widget.isLoggedIn ? 'main' : 'login',
               routes: {
                 // SplashScreen.routeName: (context) => SplashScreen(),
                 'login': (context) => const LoginScreen(),
@@ -61,9 +63,8 @@ class _MyAppState extends State<MyApp> {
 Future<bool> checkIfLoggedIn() async {
   final SharedPreferences prefs = await SharedPreferences.getInstance();
   final String? accessToken = prefs.getString('access_token');
-  
+
   bool isLoggedIn = accessToken != null;
 
   return isLoggedIn;
 }
-

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -6,13 +6,10 @@ import 'package:frontend/login/login_screen.dart';
 import 'package:frontend/model/controller/user_controller.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:frontend/main/main_screen.dart';
-import 'package:logger/logger.dart';
 import 'package:get/get.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-
-import 'package:frontend/model/data/global_variables.dart';
 
 void main() async {
   WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
@@ -27,7 +24,7 @@ void main() async {
 class MyApp extends StatefulWidget {
   final bool isLoggedIn;
 
-  const MyApp({Key? key, required this.isLoggedIn}) : super(key: key);
+  const MyApp({super.key, required this.isLoggedIn});
 
   @override
   State<MyApp> createState() => _MyAppState();
@@ -37,7 +34,7 @@ class _MyAppState extends State<MyApp> {
   @override
   // This widgets is the root of your application.
   Widget build(BuildContext context) {
-    final UserController userController = Get.put(UserController());
+    Get.put(UserController());
 
     return ScreenUtilInit(
         designSize: const Size(375, 844),
@@ -51,10 +48,10 @@ class _MyAppState extends State<MyApp> {
                 // SplashScreen.routeName: (context) => SplashScreen(),
                 'login': (context) => const LoginScreen(),
                 'main': (context) => const MainScreen(),
-                'create_challenge': (context) => CreateChallenge_fir(),
+                'create_challenge': (context) => const CreateChallenge_fir(),
                 'detail_challenge': (context) => ChallengeDetailScreen(),
                 // 'state_challenge' : (context) => ChallengeStateScreen(),
-                'community': (context) => TabCommunityScreen(),
+                'community': (context) => const TabCommunityScreen(),
               });
         });
   }

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -5,32 +5,38 @@ import 'package:frontend/community/tab_community_screen.dart';
 import 'package:frontend/login/login_screen.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:frontend/main/main_screen.dart';
+import 'package:logger/logger.dart';
 import 'package:get/get.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() async {
   WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
   await initializeDateFormatting('ko_KR', null);
 
-  // Firebase.initializeApp().whenComplete(() => {
+   
+  bool isLoggedIn = await checkIfLoggedIn();
   FlutterNativeSplash.remove();
-// });
-  runApp(const MyApp());
+  runApp(MyApp(isLoggedIn: isLoggedIn));
 }
 
 class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
+  final bool isLoggedIn;
+
+  const MyApp({Key? key, required this.isLoggedIn}) : super(key: key);
 
   @override
   State<MyApp> createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {
+
   @override
   // This widgets is the root of your application.
   Widget build(BuildContext context) {
+    
     return ScreenUtilInit(
         designSize: const Size(375, 844),
         minTextAdapt: true,
@@ -38,7 +44,7 @@ class _MyAppState extends State<MyApp> {
           return GetMaterialApp(
               theme: ThemeData(primaryColor: Colors.white),
               // navigatorObservers: <NavigatorObserver>[observer],
-              initialRoute:  'main',
+              initialRoute:  widget.isLoggedIn ? 'main' : 'login',
               routes: {
                 // SplashScreen.routeName: (context) => SplashScreen(),
                 'login': (context) => const LoginScreen(),
@@ -51,3 +57,13 @@ class _MyAppState extends State<MyApp> {
         });
   }
 }
+
+Future<bool> checkIfLoggedIn() async {
+  final SharedPreferences prefs = await SharedPreferences.getInstance();
+  final String? accessToken = prefs.getString('access_token');
+  
+  bool isLoggedIn = accessToken != null;
+
+  return isLoggedIn;
+}
+

--- a/frontend/lib/main/bottom_tabs/home/home_components/home_top_stack_box.dart
+++ b/frontend/lib/main/bottom_tabs/home/home_components/home_top_stack_box.dart
@@ -7,6 +7,8 @@ import 'package:frontend/main/bottom_tabs/home/home_components/home_challenge_re
 import 'package:frontend/main/bottom_tabs/home/home_components/home_challenge_state_box.dart';
 import 'package:frontend/model/config/palette.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:frontend/model/controller/user_controller.dart';
+import 'package:get/get.dart';
 
 class ChallengeTopStack extends StatefulWidget {
   const ChallengeTopStack({Key? key}) : super(key: key);
@@ -16,6 +18,8 @@ class ChallengeTopStack extends StatefulWidget {
 }
 
 class _ChallengeTopStackState extends State<ChallengeTopStack> {
+  final UserController userController = Get.find<UserController>();
+
   @override
   Widget build(BuildContext context) {
     return Stack(
@@ -23,7 +27,7 @@ class _ChallengeTopStackState extends State<ChallengeTopStack> {
       children: [
         Column(mainAxisSize: MainAxisSize.min, children: [
           Container(
-            child: ChallengeRecommendBox(name: '신혜은'),
+            child: ChallengeRecommendBox(name: userController.user.name),
           ),
           Container(height: 100, color: Palette.mainPurple),
           Container(height: 80, color: Colors.transparent),
@@ -32,7 +36,9 @@ class _ChallengeTopStackState extends State<ChallengeTopStack> {
           right: 0,
           left: 0,
           top: 150,
-          child: Padding(padding: EdgeInsets.symmetric(horizontal: 20, vertical: 10), child: ChallengeStateBox()),
+          child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+              child: ChallengeStateBox()),
         ),
       ],
     );

--- a/frontend/lib/main/bottom_tabs/mypage/mypage_screen.dart
+++ b/frontend/lib/main/bottom_tabs/mypage/mypage_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:frontend/login/login_screen.dart';
 import 'package:frontend/main/bottom_tabs/mypage/mypage_pupleBtnBox.dart';
 import 'package:frontend/main/bottom_tabs/mypage/widget/mypage_user_inform.dart';
+import 'package:get/get.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class MyPageScreen extends StatefulWidget {
   const MyPageScreen({super.key});
@@ -10,9 +13,6 @@ class MyPageScreen extends StatefulWidget {
 }
 
 class _MyPageScreenState extends State<MyPageScreen> {
-
-
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -31,12 +31,24 @@ class _MyPageScreenState extends State<MyPageScreen> {
             )),
         body: SingleChildScrollView(
             child: Padding(
-          padding: EdgeInsets.symmetric(horizontal: 10),
+          padding: const EdgeInsets.symmetric(horizontal: 10),
           child: Column(
             children: [
               UserInformation(),
-              SizedBox(height: 5),
-              PurpleThreeBox()
+              const SizedBox(height: 5),
+              PurpleThreeBox(),
+              TextButton(
+                onPressed: () async {
+                  final SharedPreferences prefs =
+                      await SharedPreferences.getInstance();
+                  prefs.remove('access_token');
+                  Get.offAll(const LoginScreen());
+                },
+                child: const Text(
+                  '로그아웃',
+                  selectionColor: Colors.black,
+                ),
+              ),
             ],
           ),
         )));

--- a/frontend/lib/main/bottom_tabs/mypage/widget/mypage_user_inform.dart
+++ b/frontend/lib/main/bottom_tabs/mypage/widget/mypage_user_inform.dart
@@ -3,11 +3,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:frontend/model/config/palette.dart';
+import 'package:frontend/model/controller/user_controller.dart';
+import 'package:get/get.dart';
 
 class UserInformation extends StatelessWidget {
-  const UserInformation({super.key});
+  UserInformation({super.key});
 
-  final String userName = '신혜은';
+  final UserController userController = Get.find<UserController>();
+
+  // final String userName = ;
   final int followingNum = 10;
   final int followerNum = 1;
   final int level = 1;
@@ -56,7 +60,7 @@ class UserInformation extends StatelessWidget {
         child: Stack(children: [
           CircleAvatar(
             radius: 70,
-            backgroundImage: AssetImage('assets/images/detail_man_icon.png'),
+            backgroundImage: NetworkImage(userController.user.avatar),
           ),
           Positioned(
               child: SvgPicture.asset('assets/svgs/level_stack.svg'),
@@ -78,38 +82,36 @@ class UserInformation extends StatelessWidget {
   }
 
   Widget nameText(Size screenSize) {
-    return  Row(
-            mainAxisAlignment: MainAxisAlignment.start,
+    return Row(mainAxisAlignment: MainAxisAlignment.start, children: [
+      Container(
+          width: userController.user.name.length * 25,
+          height: 35,
+          child: Stack(
+            alignment: Alignment.bottomCenter,
             children: [
-          Container(
-              width: userName.length * 25,
-              height: 35,
-              child: Stack(
-                alignment: Alignment.bottomCenter,
-                children: [
-                  Container(
-                    height: 10, // 밑줄의 높이
-                    color: Palette.purPle50, // 밑줄 색상 설정
-                  ),
-                  Text(
-                    userName,
-                    style: TextStyle(
-                      fontSize: 17,
-                      fontFamily: 'Pretendard',
-                      fontWeight: FontWeight.w500,
-                      overflow: TextOverflow.ellipsis, // 오버플로우 발생 시 처리 방식 설정
-                    ),
-                  )
-                ],
-              )),
-          Text(
-            '님 반가워요!',
-            style: TextStyle(
-                overflow: TextOverflow.fade,
-                fontSize: 17,
-                fontFamily: 'Pretendard',
-                fontWeight: FontWeight.w500),
-          )
-        ]);
+              Container(
+                height: 10, // 밑줄의 높이
+                color: Palette.purPle50, // 밑줄 색상 설정
+              ),
+              Text(
+                userController.user.name,
+                style: TextStyle(
+                  fontSize: 17,
+                  fontFamily: 'Pretendard',
+                  fontWeight: FontWeight.w500,
+                  overflow: TextOverflow.ellipsis, // 오버플로우 발생 시 처리 방식 설정
+                ),
+              )
+            ],
+          )),
+      Text(
+        '님 반가워요!',
+        style: TextStyle(
+            overflow: TextOverflow.fade,
+            fontSize: 17,
+            fontFamily: 'Pretendard',
+            fontWeight: FontWeight.w500),
+      )
+    ]);
   }
 }

--- a/frontend/lib/main/main_screen.dart
+++ b/frontend/lib/main/main_screen.dart
@@ -1,8 +1,15 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:frontend/main/bottom_tabs/home/home_screen.dart';
 import 'package:frontend/main/bottom_tabs/myRoutineUp/myRoutineUp_screen.dart';
 import 'package:frontend/main/bottom_tabs/mypage/mypage_screen.dart';
 import 'package:frontend/model/config/palette.dart';
+import 'package:frontend/model/controller/user_controller.dart';
+import 'package:frontend/model/data/global_variables.dart';
+import 'package:frontend/model/data/user.dart';
+import 'package:http/http.dart' as http;
+import 'package:get/get.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class MainScreen extends StatefulWidget {
   const MainScreen({super.key});
@@ -26,6 +33,30 @@ class _MainScreenState extends State<MainScreen> {
     });
   }
 
+  void _getUserData() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final String? accessToken = prefs.getString('access_token');
+    final String url = '${GlobalVariables().SERVER_URL}/users/me';
+
+    final response = await http.get(
+      Uri.parse(url),
+      headers: <String, String>{
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $accessToken',
+      },
+    );
+
+    if (response.statusCode == 200) {
+      UserController userController = Get.find<UserController>();
+      final Map<String, dynamic> data =
+          jsonDecode(utf8.decode(response.bodyBytes));
+      final User user = User.fromJson(data);
+      userController.saveUser(user);
+    } else {
+      Get.snackbar('로그인 실패', '다시 로그인해주세요');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -33,10 +64,10 @@ class _MainScreenState extends State<MainScreen> {
         child: _widgetOptions.elementAt(_selectedIndex),
       ),
       bottomNavigationBar: BottomNavigationBar(
-        items: <BottomNavigationBarItem>[
-          const BottomNavigationBarItem(icon: Icon(Icons.home), label: "홈"),
-          const BottomNavigationBarItem(icon: Icon(Icons.timelapse), label: "나의 루틴업"),
-          const BottomNavigationBarItem(icon: Icon(Icons.person), label: "마이페이지")
+        items: const <BottomNavigationBarItem>[
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: "홈"),
+          BottomNavigationBarItem(icon: Icon(Icons.timelapse), label: "나의 루틴업"),
+          BottomNavigationBarItem(icon: Icon(Icons.person), label: "마이페이지")
         ],
         currentIndex: _selectedIndex,
         selectedItemColor: Palette.mainPurple,
@@ -45,18 +76,15 @@ class _MainScreenState extends State<MainScreen> {
     );
   }
 
-
   @override
   void initState() {
     //해당 클래스가 호출되었을떄
     super.initState();
-
+    _getUserData();
   }
 
   @override
   void dispose() {
     super.dispose();
   }
-
-
 }

--- a/frontend/lib/model/controller/user_controller.dart
+++ b/frontend/lib/model/controller/user_controller.dart
@@ -1,0 +1,38 @@
+import 'package:get/get.dart';
+import 'package:get_storage/get_storage.dart';
+import 'package:frontend/model/data/user.dart';
+
+class UserController extends GetxController {
+  final _user = User(
+    id: 0,
+    email: "",
+    avatar: "",
+    name: "",
+    level: 0,
+    xp: 0,
+    point: 0,
+  ).obs;
+
+  User get user => _user.value;
+
+  @override
+  void onInit() {
+    // 앱 시작 시 저장된 데이터 로드
+    _loadUser();
+    super.onInit();
+  }
+
+  void _loadUser() async {
+    final box = GetStorage();
+    if (box.hasData('user')) {
+      final json = box.read('user');
+      _user(User.fromJson(json));
+    }
+  }
+
+  void saveUser(User user) async {
+    final box = GetStorage();
+    await box.write('user', user.toJson());
+    _user(user);
+  }
+}

--- a/frontend/lib/model/data/global_variables.dart
+++ b/frontend/lib/model/data/global_variables.dart
@@ -1,0 +1,4 @@
+class GlobalVariables {
+  final String SERVER_URL = 'http://3.34.14.45:8080';
+  final String SERVER_URL_NIP = 'http://3.34.14.45.nip.io:8080';
+}

--- a/frontend/lib/model/data/global_variables.dart
+++ b/frontend/lib/model/data/global_variables.dart
@@ -1,4 +1,0 @@
-class GlobalVariables {
-  final String SERVER_URL = 'http://3.34.14.45:8080';
-  final String SERVER_URL_NIP = 'http://3.34.14.45.nip.io:8080';
-}

--- a/frontend/lib/model/data/user.dart
+++ b/frontend/lib/model/data/user.dart
@@ -1,0 +1,43 @@
+class User {
+  int id;
+  String email;
+  String avatar;
+  String name;
+  int level;
+  int xp;
+  int point;
+
+  User({
+    required this.id,
+    required this.email,
+    required this.avatar,
+    required this.name,
+    required this.level,
+    required this.xp,
+    required this.point,
+  });
+
+  factory User.fromJson(Map<String, dynamic> json) {
+    return User(
+      id: json['id'],
+      email: json['email'],
+      avatar: json['avatar'],
+      name: json['name'],
+      level: json['level'],
+      xp: json['xp'],
+      point: json['point'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = new Map<String, dynamic>();
+    data['id'] = this.id;
+    data['email'] = this.email;
+    data['avatar'] = this.avatar;
+    data['name'] = this.name;
+    data['level'] = this.level;
+    data['xp'] = this.xp;
+    data['point'] = this.point;
+    return data;
+  }
+}

--- a/frontend/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/frontend/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import file_selector_macos
 import flutter_web_auth_2
+import path_provider_foundation
 import shared_preferences_foundation
 import url_launcher_macos
 import window_to_front
@@ -14,6 +15,7 @@ import window_to_front
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterWebAuth2Plugin.register(with: registry.registrar(forPlugin: "FlutterWebAuth2Plugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WindowToFrontPlugin.register(with: registry.registrar(forPlugin: "WindowToFrontPlugin"))

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -272,6 +272,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.6.6"
+  get_storage:
+    dependency: "direct main"
+    description:
+      name: get_storage
+      sha256: "39db1fffe779d0c22b3a744376e86febe4ade43bf65e06eab5af707dc84185a2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   html:
     dependency: transitive
     description:
@@ -281,7 +289,7 @@ packages:
     source: hosted
     version: "0.15.4"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
@@ -472,6 +480,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: c9e7d3a4cd1410877472158bee69963a4579f78b68c65a2b7d40d1a7a88bb161
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: a248d8146ee5983446bf03ed5ea8f6533129a12b11f12057ad1b4a67a2b3b41d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.4"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "5a7999be66e000916500be4f15a3633ebceb8302719b47b9cc49ce924125350f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   path_provider_linux:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   logger: ^2.2.0
   flutter_native_splash: ^2.2.7
   get_storage: ^2.1.1
+  http: ^1.2.1
 
 dev_dependencies:
   flutter_test:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   shared_preferences: ^2.2.3
   logger: ^2.2.0
   flutter_native_splash: ^2.2.7
+  get_storage: ^2.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 개요 :mag:

구글 로그인 시 받아온 access_token의 유무를 이용해 로그인 유지를 구현했고, 해당 토큰을 사용해 유저 정보를 받아왔습니다`.

### 연관된 이슈

#15 

## 작업사항 :memo:

- SharedPreferences를 이용해서 access_token 저장
- 해당 값이 있다면 로그인 된것으로 판단
- 메인에서 해당 값을 이용해 유저 정보를 가져온 뒤 FutureBuilder를 사용해서 값을 불러온 뒤 빌드

### 스크린샷 (선택)

## 테스트 방법

`리뷰하는 사람이 어떻게 테스트할 수 있을지 간략히 써주세요.`

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
