### PR TITLE
[be/feat] 백엔드 챌린지 보호 및 ChallengeSimpleResponse에 isPrivate 추가

### DIFF
--- a/backend/src/main/java/km/cd/backend/challenge/controller/ChallengeController.java
+++ b/backend/src/main/java/km/cd/backend/challenge/controller/ChallengeController.java
@@ -3,7 +3,6 @@ package km.cd.backend.challenge.controller;
 import jakarta.validation.Valid;
 import java.util.List;
 import km.cd.backend.challenge.domain.Challenge;
-import km.cd.backend.challenge.domain.mapper.ChallengeMapper;
 import km.cd.backend.challenge.dto.request.ChallengeJoinRequest;
 import km.cd.backend.challenge.dto.response.ChallengeInformationResponse;
 import km.cd.backend.challenge.dto.request.ChallengeInviteCodeRequest;
@@ -61,8 +60,12 @@ public class ChallengeController {
     
 
     @GetMapping("/{challengeId}")
-    public ResponseEntity<ChallengeInformationResponse> getChallenge(@PathVariable Long challengeId) {
-        ChallengeInformationResponse challengeInformationResponse =  challengeService.getChallenge(challengeId);
+    public ResponseEntity<ChallengeInformationResponse> getChallenge(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @PathVariable Long challengeId,
+            @RequestParam String code
+    ) {
+        ChallengeInformationResponse challengeInformationResponse =  challengeService.getChallenge(challengeId, principalDetails.getUserId(), code);
         return ResponseEntity.ok(challengeInformationResponse);
     }
     

--- a/backend/src/main/java/km/cd/backend/challenge/controller/ChallengeController.java
+++ b/backend/src/main/java/km/cd/backend/challenge/controller/ChallengeController.java
@@ -63,7 +63,7 @@ public class ChallengeController {
     public ResponseEntity<ChallengeInformationResponse> getChallenge(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @PathVariable Long challengeId,
-            @RequestParam String code
+            @RequestParam(name = "code", required = false, defaultValue = "") String code
     ) {
         ChallengeInformationResponse challengeInformationResponse =  challengeService.getChallenge(challengeId, principalDetails.getUserId(), code);
         return ResponseEntity.ok(challengeInformationResponse);

--- a/backend/src/main/java/km/cd/backend/challenge/dto/response/ChallengeSimpleResponse.java
+++ b/backend/src/main/java/km/cd/backend/challenge/dto/response/ChallengeSimpleResponse.java
@@ -30,6 +30,9 @@ public record ChallengeSimpleResponse(
         String imageUrl,
 
         @Schema(description = "챌린지 종료 여부")
-        boolean isEnded
+        boolean isEnded,
+
+        @Schema(description = "챌린지 비공개 여부")
+        boolean isPrivate
 ) {
 }


### PR DESCRIPTION
## 개요 :mag:

비공개 챌린지는 코드를 입력해야 조회가 가능하도록 해야하고, 따라서 코드를 입력해서 요청을 보내는 과정을 추가했습니다.

### 연관된 이슈

## 작업사항 :memo:

- ChallengeSimpleResponse에 isPrivate 추가
- Challenge 조회 로직에 Owner인지 확인하는 과정과 비공개라면 코드가 맞는지 확인하는 과정 추가

### 스크린샷 (선택)

## 테스트 방법

`리뷰하는 사람이 어떻게 테스트할 수 있을지 간략히 써주세요.`

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
