### PR TITLE
[backend/feat] 유저 정보에 프로필 이미지 추가 & follow list 조회 시 친구 이미지 첨부 

### DIFF
--- a/backend/src/main/java/km/cd/backend/challenge/dto/enums/FilePathEnum.java
+++ b/backend/src/main/java/km/cd/backend/challenge/dto/enums/FilePathEnum.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public enum FilePathEnum {
   CHALLENGES("challenges"),
   PARTICIPANTS("participants"),
+  USER("user"),
   COMMUNITY("community");
   
   private final String path;

--- a/backend/src/main/java/km/cd/backend/challenge/service/ChallengeService.java
+++ b/backend/src/main/java/km/cd/backend/challenge/service/ChallengeService.java
@@ -25,7 +25,6 @@ import km.cd.backend.common.error.ExceptionCode;
 import km.cd.backend.common.utils.RandomUtil;
 import km.cd.backend.common.utils.redis.RedisUtil;
 import km.cd.backend.common.utils.s3.S3Uploader;
-import km.cd.backend.common.utils.sms.SmsCertificationDao;
 import km.cd.backend.common.utils.sms.SmsUtil;
 import km.cd.backend.community.repository.PostRepository;
 import km.cd.backend.user.domain.User;
@@ -74,9 +73,8 @@ public class ChallengeService {
         List<String> imagePaths = images.stream().map(
             image -> s3Uploader.uploadFileToS3(image, FilePathEnum.CHALLENGES.getPath())
             ).toList();
-            challenge.setChallengeImagePaths(imagePaths);
-            
-
+        challenge.setChallengeImagePaths(imagePaths);
+        
         // 인증 성공 이미지 업로드
         String successImagePath = s3Uploader.uploadFileToS3(successfulVerificationImage, FilePathEnum.CHALLENGES.getPath());
         challenge.setSuccessfulVerificationImage(successImagePath);

--- a/backend/src/main/java/km/cd/backend/common/error/ExceptionCode.java
+++ b/backend/src/main/java/km/cd/backend/common/error/ExceptionCode.java
@@ -19,7 +19,6 @@ public enum ExceptionCode { // 예외 발생시, body에 실어 날려줄 상태
     
     ALREADY_LIKED(400, "LIKE_001", "이미 '좋아요'를 누른 상태입니다."),
     LIKE_NOT_FOUND(400, "LIKE_003", "'좋아요'를 누르지 않은 상태입니다."),
-    IMAGE_IS_NULL(400, "IMAGE_001", "이미지를 확인해주세요."),
     
     ALREADY_SIGNED_UP_ERROR(400, "SIGNUP_001", "이미 화원가입 된 이메일입니다."),
     INVALID_EMAIL_PASSWORD_ERROR(400, "AUTH_003", "유효하지 않은 이메일 또는 비밀번호입니다."),
@@ -34,6 +33,8 @@ public enum ExceptionCode { // 예외 발생시, body에 실어 날려줄 상태
     USER_CAN_NOT_BE_NULL(400, "USER_005", "사용자는 null이 될 수 없습니다."),
     USER_ID_NOT_FOUND(404, "USER_006", "해당되는 id의 사용자를 찾을 수 없습니다."),
     
+    IMAGE_IS_NULL(400, "IMAGE_001", "이미지를 확인해주세요."),
+    IMAGE_DELETION_ERROR(403, "IMG_001", "이미지를 삭제할 수 없습니다."),
     
     UNAUTHORIZED_ERROR(401, "AUTH_001", "인증되지 않았습니다. 접근 권한이 없습니다."),
     FORBIDDEN_ERROR(403, "AUTH_002", "이 리소스에 접근할 권한이 없습니다."),

--- a/backend/src/main/java/km/cd/backend/common/utils/s3/S3Uploader.java
+++ b/backend/src/main/java/km/cd/backend/common/utils/s3/S3Uploader.java
@@ -4,6 +4,8 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import km.cd.backend.common.error.CustomException;
+import km.cd.backend.common.error.ExceptionCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -47,7 +49,6 @@ public class S3Uploader {
     return uploadImageUrl;
   }
 
-
   /**
    * S3로 업로드
    * @param uploadFile : 업로드할 파일
@@ -65,9 +66,9 @@ public class S3Uploader {
    * S3에 있는 파일 삭제
    * 영어 파일만 삭제 가능 -> 한글 이름 파일은 안됨
    */
-  public void deleteS3(String filePath) throws Exception {
+  public void deleteS3(String filePath){
     try{
-      String key = filePath.substring(56); // 폴더/파일.확장자
+      String key = filePath.substring(53); // 폴더/파일.확장자
 
       try {
         amazonS3Client.deleteObject(bucket, key);
@@ -77,6 +78,7 @@ public class S3Uploader {
 
     } catch (Exception exception) {
       log.info(exception.getMessage());
+      throw new CustomException(ExceptionCode.IMAGE_DELETION_ERROR);
     }
     log.info("[S3Uploader] : S3에 있는 파일 삭제");
   }

--- a/backend/src/main/java/km/cd/backend/user/UserController.java
+++ b/backend/src/main/java/km/cd/backend/user/UserController.java
@@ -49,18 +49,16 @@ public class UserController {
     
     @GetMapping("/{targetEmail}/following")
     public ResponseEntity<List<FriendListResponse>> getFollowingList(
-        @PathVariable String targetEmail,
-        @AuthenticationPrincipal PrincipalDetails principalDetails
+        @PathVariable String targetEmail
     ) {
-        return ResponseEntity.ok(userService.getFollowingList(targetEmail, principalDetails.getUserId()));
+        return ResponseEntity.ok(userService.getFollowingList(targetEmail));
     }
     
     @GetMapping("/{targetEmail}/follower")
     public ResponseEntity<List<FriendListResponse>> getFollwerList(
-        @PathVariable String targetEmail,
-        @AuthenticationPrincipal PrincipalDetails principalDetails
+        @PathVariable String targetEmail
     ) {
-        return ResponseEntity.ok(userService.getFollwerList(targetEmail, principalDetails.getUserId()));
+        return ResponseEntity.ok(userService.getFollwerList(targetEmail));
     }
     
     @DeleteMapping("/follow/{targetEmail}")

--- a/backend/src/main/java/km/cd/backend/user/UserController.java
+++ b/backend/src/main/java/km/cd/backend/user/UserController.java
@@ -8,16 +8,20 @@ import km.cd.backend.user.dto.UserResponse;
 import km.cd.backend.user.dto.FriendListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/users")
@@ -68,7 +72,6 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.ACCEPTED).build();
     }
     
-
     @GetMapping("/me/challenges")
     public ResponseEntity<List<ChallengeSimpleResponse>> myChallenges(
             @AuthenticationPrincipal PrincipalDetails principalDetails
@@ -77,5 +80,34 @@ public class UserController {
         List<ChallengeSimpleResponse> challengeSimpleResponses = userService.getChallengesByUserId(userId);
         return ResponseEntity.ok(challengeSimpleResponses);
     }
-
+    
+    @PostMapping(path = "/image", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<UserResponse> uploadProfileImage(
+        @RequestPart(name = "profileImage") MultipartFile profileImage,
+        @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        return ResponseEntity.ok(userService.uploadProfileImage(profileImage, principalDetails.getUserId()));
+    }
+    
+    @PutMapping(path = "/image", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<UserResponse> updateProfileImage(
+        @RequestPart(name = "profileImage") MultipartFile profileImage,
+        @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        return ResponseEntity.ok(userService.updateProfileImage(profileImage, principalDetails.getUserId()));
+    }
+    
+    @DeleteMapping("/image")
+    public ResponseEntity<UserResponse> deleteProfileImage(
+        @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        return ResponseEntity.ok(userService.deleteProfileImage(principalDetails.getUserId()));
+    }
+    
+    @GetMapping("/image")
+    public ResponseEntity<String> getProfileImage(
+        @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        return ResponseEntity.ok(userService.getProfileImage(principalDetails.getUserId()));
+    }
 }

--- a/backend/src/main/java/km/cd/backend/user/UserService.java
+++ b/backend/src/main/java/km/cd/backend/user/UserService.java
@@ -1,5 +1,6 @@
 package km.cd.backend.user;
 
+import java.util.ArrayList;
 import km.cd.backend.challenge.domain.Challenge;
 import km.cd.backend.challenge.domain.Participant;
 import km.cd.backend.challenge.domain.mapper.ChallengeMapper;
@@ -58,20 +59,30 @@ public class UserService {
         friendRepository.save(follow);
     }
     
-    public List<FriendListResponse> getFollowingList(String targetEmail, Long userId) {
+    public List<FriendListResponse> getFollowingList(String targetEmail) {
         User selectedUser = findByEmail(targetEmail);
-        User requestUser = findById(userId);
-        
         List<Friend> friendList = friendRepository.findByFromUser(selectedUser);
-        return FriendMapper.INSTANCE.FRIEND_LIST_RESPONSE_LIST(friendList, true);
+        
+        ArrayList<FriendListResponse> resultList = new ArrayList<>();
+        for (Friend friend : friendList) {
+            String friendImage = findByEmail(friend.getMyEmail()).getProfileImage();
+            resultList.add(FriendMapper.INSTANCE.FRIEND_LIST_RESPONSE(friend, true, friendImage));
+        }
+        
+        return resultList;
     }
     
-    public List<FriendListResponse> getFollwerList(String targetEmail, Long userId) {
+    public List<FriendListResponse> getFollwerList(String targetEmail) {
         User selectedUser = findByEmail(targetEmail);
-        User requestUser = findById(userId);
-        
         List<Friend> friendList = friendRepository.findByToUser(selectedUser);
-        return FriendMapper.INSTANCE.FRIEND_LIST_RESPONSE_LIST(friendList, false);
+        
+        ArrayList<FriendListResponse> resultList = new ArrayList<>();
+        for (Friend friend : friendList) {
+            String friendImage = findByEmail(friend.getMyEmail()).getProfileImage();
+            resultList.add(FriendMapper.INSTANCE.FRIEND_LIST_RESPONSE(friend, false, friendImage));
+        }
+        
+        return resultList;
     }
     
     public void removeFollow(String targetEmail, Long userId) {

--- a/backend/src/main/java/km/cd/backend/user/UserService.java
+++ b/backend/src/main/java/km/cd/backend/user/UserService.java
@@ -3,14 +3,18 @@ package km.cd.backend.user;
 import km.cd.backend.challenge.domain.Challenge;
 import km.cd.backend.challenge.domain.Participant;
 import km.cd.backend.challenge.domain.mapper.ChallengeMapper;
+import km.cd.backend.challenge.dto.enums.FilePathEnum;
 import km.cd.backend.challenge.dto.response.ChallengeSimpleResponse;
 import km.cd.backend.challenge.repository.ParticipantRepository;
 import km.cd.backend.common.error.CustomException;
 import km.cd.backend.common.error.ExceptionCode;
+import km.cd.backend.common.utils.s3.S3Uploader;
 import km.cd.backend.user.domain.Friend;
 import km.cd.backend.user.domain.User;
 import km.cd.backend.user.domain.mapper.FriendMapper;
+import km.cd.backend.user.domain.mapper.UserMapper;
 import km.cd.backend.user.dto.FriendListResponse;
+import km.cd.backend.user.dto.UserResponse;
 import km.cd.backend.user.repository.FriendRepository;
 import km.cd.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional
@@ -27,6 +32,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final FriendRepository friendRepository;
     private final ParticipantRepository participantRepository;
+    private final S3Uploader s3Uploader;
 
     public User findByEmail(String email) {
         return userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_FOUND));
@@ -86,4 +92,38 @@ public class UserService {
                 }
         ).toList();
     }
+    
+    public UserResponse uploadProfileImage(MultipartFile profileImage, Long userId) {
+        User user = findById(userId);
+        String profileImageUrl = s3Uploader.uploadFileToS3(profileImage, FilePathEnum.USER.getPath());
+        user.setProfileImage(profileImageUrl);
+        userRepository.save(user);
+        
+        return UserMapper.INSTANCE.userToUserResponse(user);
+    }
+    
+    public UserResponse updateProfileImage(MultipartFile profileImage, Long userId){
+        User user = findById(userId);
+        s3Uploader.deleteS3(user.getProfileImage());
+        
+        String profileImageUrl = s3Uploader.uploadFileToS3(profileImage, FilePathEnum.USER.getPath());
+        user.setProfileImage(profileImageUrl);
+        userRepository.save(user);
+        
+        return UserMapper.INSTANCE.userToUserResponse(user);
+    }
+    
+    public UserResponse deleteProfileImage(Long userId) {
+        User user = findById(userId);
+        s3Uploader.deleteS3(user.getProfileImage());
+        user.setProfileImage(null);
+        userRepository.save(user);
+        
+        return UserMapper.INSTANCE.userToUserResponse(user);
+    }
+    
+    public String getProfileImage(Long userId) {
+        return findById(userId).getProfileImage();
+    }
+    
 }

--- a/backend/src/main/java/km/cd/backend/user/domain/User.java
+++ b/backend/src/main/java/km/cd/backend/user/domain/User.java
@@ -49,6 +49,8 @@ public class User {
     @Builder.Default
     private int point = 0;
     
+    private String profileImage;
+    
     @OneToMany(mappedBy = "fromUser", cascade = CascadeType.ALL)
     private List<Friend> following = new ArrayList<>();
     

--- a/backend/src/main/java/km/cd/backend/user/domain/mapper/FriendMapper.java
+++ b/backend/src/main/java/km/cd/backend/user/domain/mapper/FriendMapper.java
@@ -1,14 +1,9 @@
 package km.cd.backend.user.domain.mapper;
 
-import java.util.ArrayList;
-import java.util.List;
 import km.cd.backend.user.domain.Friend;
-import km.cd.backend.user.domain.User;
 import km.cd.backend.user.dto.FriendListResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Named;
-import org.mapstruct.control.MappingControl.Use;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -18,15 +13,7 @@ public interface FriendMapper {
     
     @Mapping(source = "friend.id", target = "friendId")
     @Mapping(target = "friendEmail", expression = "java(isFromUser ? friend.getFriendEmail() : friend.getMyEmail())")
-    FriendListResponse FRIEND_LIST_RESPONSE(Friend friend, boolean isFromUser);
-    
-    @Named("mapFriendListResponse")
-    default ArrayList<FriendListResponse> FRIEND_LIST_RESPONSE_LIST(List<Friend> friendList, boolean isFromUser) {
-        ArrayList<FriendListResponse> resultList = new ArrayList<>();
-        for (Friend friend : friendList) {
-            resultList.add(FRIEND_LIST_RESPONSE(friend, isFromUser));
-        }
-        return resultList;
-    }
+    @Mapping(source = "friendImage", target = "friendImage")
+    FriendListResponse FRIEND_LIST_RESPONSE(Friend friend, boolean isFromUser, String friendImage);
 }
 

--- a/backend/src/main/java/km/cd/backend/user/dto/FriendListResponse.java
+++ b/backend/src/main/java/km/cd/backend/user/dto/FriendListResponse.java
@@ -9,4 +9,5 @@ public class FriendListResponse {
     private Long friendId;
     private String friendEmail;
     private String friendName;
+    private String friendImage;
 }

--- a/backend/src/main/java/km/cd/backend/user/dto/UserResponse.java
+++ b/backend/src/main/java/km/cd/backend/user/dto/UserResponse.java
@@ -5,5 +5,6 @@ public record UserResponse(
         String email,
         String avatar,
         String name,
-        int point
+        int point,
+        String profileImage
 ){ }


### PR DESCRIPTION
## 개요 :mag:

유저 정보에 프로필 이미지 추가 & follow list 조회 시 친구 이미지 첨부 

### 연관된 이슈

## 작업사항 :memo:

- 유저 이미지 CRUD 기능
- follower, following 리스트 조회 시 친구 이미지까지 같이 보내도록 수정

### 스크린샷 (선택)
![스크린샷 2024-05-15 오후 8 22 53](https://github.com/kookmin-sw/capstone-2024-31/assets/50860369/46e4ebcf-1a06-46ee-ad7b-2fc3a3f0a7e8)

![스크린샷 2024-05-15 오후 8 18 53](https://github.com/kookmin-sw/capstone-2024-31/assets/50860369/7cef1b79-9ddf-4d1d-9453-1962961174d7)


## 💬리뷰 요구사항(선택)

GET
[/users/image](http://localhost:8080/swagger-ui/index.html#/user-controller/getProfileImage)
이미지 조회하기 -> Image url 반환

PUT
[/users/image](http://localhost:8080/swagger-ui/index.html#/user-controller/updateProfileImage)
이미지 변경하기 -> 기본 이미지 삭제 후 새로운 이미지로 업로드 -> 유저 정보 반환

POST
[/users/image](http://localhost:8080/swagger-ui/index.html#/user-controller/uploadProfileImage)
이미지 업로드하기 -> 유저 정보 반환

DELETE
[/users/image](http://localhost:8080/swagger-ui/index.html#/user-controller/deleteProfileImage)
이미지 삭제하기 -> 유저 정보 반환

POST
[/users/follow/{targetEmail}](http://localhost:8080/swagger-ui/index.html#/user-controller/followFriend)
로그인된 유저가 targetEmail에 해당하는 유저 팔로우 

DELETE
[/users/follow/{targetEmail}](http://localhost:8080/swagger-ui/index.html#/user-controller/removeFollow)
로그인된 유저가 targetEmail에 해당하는 유저 언팔로우 

GET
[/users/{targetEmail}/following](http://localhost:8080/swagger-ui/index.html#/user-controller/getFollowingList)
targetEmail의 팔로잉 리스트를 받아옴

GET
[/users/{targetEmail}/follower](http://localhost:8080/swagger-ui/index.html#/user-controller/getFollwerList)
targetEmail의 팔로워 리스트를 받아옴