### PR TITLE
[backend/feat] User 이미지 저장 필드 변경 및 카테고리 기능 구현

### DIFF
--- a/backend/src/main/java/km/cd/backend/user/UserController.java
+++ b/backend/src/main/java/km/cd/backend/user/UserController.java
@@ -4,6 +4,8 @@ import km.cd.backend.challenge.dto.response.ChallengeSimpleResponse;
 import km.cd.backend.common.jwt.PrincipalDetails;
 import km.cd.backend.user.domain.User;
 import km.cd.backend.user.domain.mapper.UserMapper;
+import km.cd.backend.user.dto.UserCategoryRequest;
+import km.cd.backend.user.dto.UserDetailResponse;
 import km.cd.backend.user.dto.UserResponse;
 import km.cd.backend.user.dto.FriendListResponse;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -108,4 +111,13 @@ public class UserController {
     ) {
         return ResponseEntity.ok(userService.getProfileImage(principalDetails.getUserId()));
     }
+    
+    @PostMapping("/category")
+    public ResponseEntity<UserDetailResponse> setCategory(
+        @RequestBody UserCategoryRequest userCategoryRequest,
+        @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        return ResponseEntity.ok(userService.setCategories(userCategoryRequest, principalDetails.getUserId()));
+    }
+    
 }

--- a/backend/src/main/java/km/cd/backend/user/domain/User.java
+++ b/backend/src/main/java/km/cd/backend/user/domain/User.java
@@ -4,7 +4,10 @@ import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import km.cd.backend.challenge.domain.ChallengeCategory;
 import km.cd.backend.common.oauth2.attributes.OAuth2Attributes;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -49,13 +52,15 @@ public class User {
     @Builder.Default
     private int point = 0;
     
-    private String profileImage;
-    
     @OneToMany(mappedBy = "fromUser", cascade = CascadeType.ALL)
     private List<Friend> following = new ArrayList<>();
     
     @OneToMany(mappedBy = "toUser", cascade = CascadeType.ALL)
     private List<Friend> follower = new ArrayList<>();
+    
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Enumerated(EnumType.STRING)
+    private Set<ChallengeCategory> categories = new HashSet<>();
     
     public User(Long id, String email, String name) {
         this.id = id;

--- a/backend/src/main/java/km/cd/backend/user/domain/mapper/UserMapper.java
+++ b/backend/src/main/java/km/cd/backend/user/domain/mapper/UserMapper.java
@@ -1,8 +1,14 @@
 package km.cd.backend.user.domain.mapper;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import km.cd.backend.challenge.domain.ChallengeCategory;
 import km.cd.backend.user.domain.User;
+import km.cd.backend.user.dto.UserDetailResponse;
 import km.cd.backend.user.dto.UserResponse;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -11,4 +17,13 @@ public interface UserMapper {
     UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
 
     UserResponse userToUserResponse(User user);
+    
+    @Mapping(source = "categories", target = "categories")
+    UserDetailResponse userToUserDetailResponse(User user);
+    
+    default List<String> mapCategories(Set<ChallengeCategory> categories) {
+        return categories.stream()
+            .map(ChallengeCategory::getName)
+            .collect(Collectors.toList());
+    }
 }

--- a/backend/src/main/java/km/cd/backend/user/dto/UserCategoryRequest.java
+++ b/backend/src/main/java/km/cd/backend/user/dto/UserCategoryRequest.java
@@ -1,0 +1,9 @@
+package km.cd.backend.user.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class UserCategoryRequest {
+    List<String> categories;
+}

--- a/backend/src/main/java/km/cd/backend/user/dto/UserDetailResponse.java
+++ b/backend/src/main/java/km/cd/backend/user/dto/UserDetailResponse.java
@@ -1,0 +1,14 @@
+package km.cd.backend.user.dto;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class UserDetailResponse {
+    Long id;
+    String email;
+    String avatar;
+    String name;
+    int point;
+    List<String> categories;
+}

--- a/backend/src/main/java/km/cd/backend/user/dto/UserResponse.java
+++ b/backend/src/main/java/km/cd/backend/user/dto/UserResponse.java
@@ -5,6 +5,5 @@ public record UserResponse(
         String email,
         String avatar,
         String name,
-        int point,
-        String profileImage
+        int point
 ){ }

--- a/backend/src/test/java/km/cd/backend/challenge/fixture/ChallengeFixture.java
+++ b/backend/src/test/java/km/cd/backend/challenge/fixture/ChallengeFixture.java
@@ -33,7 +33,7 @@ public class ChallengeFixture {
 
     public static Challenge challengeWithCategory(ChallengeCategory category) {
         Challenge challenge = challenge();
-        challenge.setCategory(category);
+        challenge.setChallengeCategory(category);
         return challenge;
     }
     


### PR DESCRIPTION
## 개요 :mag:

User 이미지 저장 필드 변경 및 카테고리 기능 구현

### 연관된 이슈

## 작업사항 :memo:

- user 이미지 url 저장 필드 profileImage -> avatar로 변경
- user에 카테고리 여러 개 저장할 수 있도록 변경 (저장할 수 있는 것은 challengeCategory enum에 설정된 내용들 뿐임 !)

### 스크린샷 (선택)

## 테스트 방법

- Swagger 테스트

## 💬리뷰 요구사항(선택)

1. 필드 변경한 후 테스트 해보았는데 정상 작동 합니다 !
2. json List로 여러개 필드 넣어서 보내면 저장됩니다 !
