### PR TITLE
[backend/feat] 댓글 기능 수정

### DIFF
--- a/backend/src/main/java/km/cd/backend/community/controller/PostController.java
+++ b/backend/src/main/java/km/cd/backend/community/controller/PostController.java
@@ -4,6 +4,7 @@ import km.cd.backend.community.dto.PostSimpleResponse;
 import km.cd.backend.community.dto.PostDetailResponse;
 import km.cd.backend.community.service.LikeService;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import km.cd.backend.common.jwt.PrincipalDetails;
@@ -25,7 +26,7 @@ public class PostController {
   private final PostService postService;
   private final LikeService likeService;
 
-  @PostMapping("")
+  @PostMapping(path = "", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
   @ResponseStatus(HttpStatus.CREATED)
   public ResponseEntity<PostDetailResponse> createPost(
       @PathVariable(name = "challengeId") Long challengeId,

--- a/backend/src/main/java/km/cd/backend/community/dto/CommentResponse.java
+++ b/backend/src/main/java/km/cd/backend/community/dto/CommentResponse.java
@@ -1,10 +1,13 @@
 package km.cd.backend.community.dto;
 
 import java.util.List;
+import km.cd.backend.user.domain.User;
+import km.cd.backend.user.dto.UserResponse;
 
 public record CommentResponse(
     Long id,
     String author,
     String content,
-    List<CommentResponse> children) {
+    List<CommentResponse> children,
+    UserResponse userResponse) {
 }

--- a/backend/src/main/java/km/cd/backend/community/mapper/CommentMapper.java
+++ b/backend/src/main/java/km/cd/backend/community/mapper/CommentMapper.java
@@ -1,7 +1,11 @@
 package km.cd.backend.community.mapper;
 
+import java.util.List;
 import km.cd.backend.community.domain.Comment;
 import km.cd.backend.community.dto.CommentResponse;
+import km.cd.backend.user.domain.User;
+import km.cd.backend.user.domain.mapper.UserMapper;
+import km.cd.backend.user.dto.UserResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -12,5 +16,11 @@ public interface CommentMapper {
     CommentMapper INSTANCE = Mappers.getMapper(CommentMapper.class);
 
     @Mapping(target = "author", source = "author.name")
+    @Mapping(target = "userResponse", source = "author")
     CommentResponse entityToResponse(Comment comment);
+    
+    List<CommentResponse> COMMENT_RESPONSE_LIST(List<Comment> comments);
+    default UserResponse USER_RESPONSE(User user) {
+        return UserMapper.INSTANCE.userToUserResponse(user);
+    }
 }

--- a/backend/src/main/java/km/cd/backend/community/mapper/PostMapper.java
+++ b/backend/src/main/java/km/cd/backend/community/mapper/PostMapper.java
@@ -10,6 +10,7 @@ import km.cd.backend.community.dto.PostRequest;
 import km.cd.backend.community.dto.PostDetailResponse;
 import km.cd.backend.community.dto.PostSimpleResponse;
 import km.cd.backend.user.domain.User;
+import km.cd.backend.user.domain.mapper.UserMapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -34,11 +35,13 @@ public interface PostMapper {
   @Named("mapComments")
   default List<CommentResponse> mapComments(List<Comment> comments) {
     return comments.stream()
+        .filter(comment -> !comment.hasParent())
         .map(comment -> new CommentResponse(
             comment.getId(),
             comment.getAuthor().getName(),
             comment.isDeleted() ? CONTENT_DELETE : comment.getContent(),
-            comment.hasParent() ? mapComments(comment.getChildren()) : new ArrayList<>()))
+            CommentMapper.INSTANCE.COMMENT_RESPONSE_LIST(comment.getChildren()),
+            UserMapper.INSTANCE.userToUserResponse(comment.getAuthor())))
         .collect(Collectors.toList());
   }
 

--- a/backend/src/main/java/km/cd/backend/community/service/CommentService.java
+++ b/backend/src/main/java/km/cd/backend/community/service/CommentService.java
@@ -41,6 +41,7 @@ public class CommentService {
             Comment parent = commentRepository.findById(parentId)
                     .orElseThrow(() -> new CustomException(ExceptionCode.PARENT_COMMENT_NOT_FOUND));
             comment.setParent(parent);
+            parent.getChildren().add(comment);
         }
         commentRepository.save(comment);
         return CommentMapper.INSTANCE.entityToResponse(comment);


### PR DESCRIPTION
## 개요 :mag:

프론트 요청에 따른 댓글 기능 수정
- 첫 번째 댓글한테는 대댓글이 안 됨
- 대댓글이 2번씩 출력

### 연관된 이슈

## 작업사항 :memo:

- 댓글마다 유저 정보 포함
{
          "id": 2,
          "author": "혁규올시다~",
          "content": "당신도 ㅋ",
          "children": [],
          "userResponse": {
            "id": 1,
            "email": "ehyeok9",
            "avatar": null,
            "name": "혁규올시다~",
            "point": 0
          }
        }
- 무한 depth 댓글 -> depth를 2까지만 줄여서 에러 수정

### 스크린샷 (선택)
<img width="873" alt="스크린샷 2024-05-16 오전 10 32 22" src="https://github.com/kookmin-sw/capstone-2024-31/assets/50860369/1e5af903-738c-4bb7-ba54-08375f89f585">

## 테스트 방법

-Swagger 테스트

