### PR TITLE
[backend/feat] 챌린지 진행 상태 필드 추가 및 Date -> LocalDate로 타입 변경

### DIFF
--- a/backend/src/main/java/km/cd/backend/challenge/domain/Challenge.java
+++ b/backend/src/main/java/km/cd/backend/challenge/domain/Challenge.java
@@ -2,11 +2,11 @@ package km.cd.backend.challenge.domain;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
+import java.time.LocalDate;
 import km.cd.backend.certification.domain.CertificationType;
 import lombok.*;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 @Entity
@@ -30,9 +30,9 @@ public class Challenge {
     
     private Integer challengePeriod;
 
-    private Date startDate;
+    private LocalDate startDate;
 
-    private Date endDate;
+    private LocalDate endDate;
 
     private String certificationFrequency;
 
@@ -58,8 +58,7 @@ public class Challenge {
 
     private String successfulVerificationImage;
     
-    @Builder.Default
-    private Boolean isEnded = false;
+    private String status;
     
     @Builder.Default
     private Integer totalParticipants = 0;
@@ -75,9 +74,5 @@ public class Challenge {
     
     public void increaseNumOfParticipants() {
         totalParticipants += 1;
-    }
-
-    public void finishChallenge() {
-        this.isEnded = true;
     }
 }

--- a/backend/src/main/java/km/cd/backend/challenge/domain/mapper/ChallengeMapper.java
+++ b/backend/src/main/java/km/cd/backend/challenge/domain/mapper/ChallengeMapper.java
@@ -1,12 +1,9 @@
 package km.cd.backend.challenge.domain.mapper;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
-import km.cd.backend.certification.domain.CertificationType;
 import km.cd.backend.challenge.domain.Challenge;
 import km.cd.backend.challenge.domain.Participant;
 import km.cd.backend.challenge.dto.response.ChallengeInformationResponse;
@@ -35,7 +32,7 @@ public interface ChallengeMapper {
     @Mapping(target = "successfulVerificationImage", ignore = true)
     @Mapping(target = "failedVerificationImage", ignore = true)
     @Mapping(target = "certificationType", ignore = true)
-    @Mapping(target = "isEnded", ignore = true)
+    @Mapping(target = "status", ignore = true)
     @Mapping(target = "totalParticipants", ignore = true)
     @Mapping(target = "totalCertificationCount", expression = "java(calculateTotalCertificationCount(convertNumber(request.getChallengePeriod()), request.getCertificationFrequency()))")
     Challenge requestToEntity(ChallengeCreateRequest request);
@@ -58,25 +55,16 @@ public interface ChallengeMapper {
     default int calculateTotalCertificationCount(Integer challengePeriod, String certificationFrequency) {
         return challengePeriod * ChallengeFrequency.findByFrequency(certificationFrequency).getDaysPerWeek();
     }
-
-
-    default Date parseDateString(String dateString) {
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
-        try {
-            return simpleDateFormat.parse(dateString);
-        } catch (ParseException e) {
-            return null;
-        }
+    
+    
+    default LocalDate parseDateString(String dateString) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return LocalDate.parse(dateString, formatter);
     }
 
-    default Date calculateEndDate(Date StartDate, String challengePeriod) {
+    default LocalDate calculateEndDate(LocalDate StartDate, String challengePeriod) {
         int weeks = convertNumber(challengePeriod);
-
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTime(StartDate);
-        calendar.add(Calendar.WEEK_OF_YEAR, weeks);
-
-        return calendar.getTime();
+        return StartDate.plusWeeks(weeks);
     }
 
     default Integer convertNumber(String sentence) {

--- a/backend/src/main/java/km/cd/backend/challenge/dto/enums/ChallengeStatus.java
+++ b/backend/src/main/java/km/cd/backend/challenge/dto/enums/ChallengeStatus.java
@@ -1,0 +1,14 @@
+package km.cd.backend.challenge.dto.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChallengeStatus {
+    NOT_STARTED("진행전"),
+    IN_PROGRESS("진행중"),
+    COMPLETED("진행완료");
+    
+    private final String description;
+}

--- a/backend/src/main/java/km/cd/backend/challenge/dto/response/ChallengeInformationResponse.java
+++ b/backend/src/main/java/km/cd/backend/challenge/dto/response/ChallengeInformationResponse.java
@@ -1,8 +1,8 @@
 package km.cd.backend.challenge.dto.response;
 
+import java.time.LocalDate;
 import lombok.Data;
 
-import java.util.Date;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 
@@ -21,9 +21,9 @@ public class ChallengeInformationResponse {
     
     private Integer challengePeriod;
     
-    private Date startDate;
+    private LocalDate startDate;
     
-    private Date endDate;
+    private LocalDate endDate;
     
     private String certificationFrequency;
     
@@ -43,7 +43,7 @@ public class ChallengeInformationResponse {
     
     private String successfulVerificationImage;
     
-    private Boolean isEnded;
+    private String status;
     
     private Integer totalParticipants;
 }

--- a/backend/src/main/java/km/cd/backend/challenge/dto/response/ChallengeSimpleResponse.java
+++ b/backend/src/main/java/km/cd/backend/challenge/dto/response/ChallengeSimpleResponse.java
@@ -3,36 +3,36 @@ package km.cd.backend.challenge.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 public record ChallengeSimpleResponse(
-
-        @Schema(description = "챌린지 id")
+    
+    @Schema(description = "챌린지 id")
         Long id,
-
-        @Schema(description = "챌린지 이름")
+    
+    @Schema(description = "챌린지 이름")
         String challengeName,
-
-        @Schema(description = "챌린지 시작일")
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
-        Date startDate,
-
-        @Schema(description = "챌린지 기간")
+    
+    @Schema(description = "챌린지 시작일")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        LocalDate startDate,
+    
+    @Schema(description = "챌린지 기간")
         Integer challengePeriod,
-
-        @Schema(description = "인증 빈도")
+    
+    @Schema(description = "인증 빈도")
         String certificationFrequency,
-
-        @Schema(description = "전체 참여 인원")
+    
+    @Schema(description = "전체 참여 인원")
         int totalParticipants,
-
-        @Schema(description = "챌린지 대표 이미지 url")
+    
+    @Schema(description = "챌린지 대표 이미지 url")
         String imageUrl,
+    
+    @Schema(description = "챌린지 종료 여부")
+        String status,
 
-        @Schema(description = "챌린지 종료 여부")
-        boolean isEnded,
-
-        @Schema(description = "챌린지 비공개 여부")
+    @Schema(description = "챌린지 비공개 여부")
         boolean isPrivate
 ) {
 }

--- a/backend/src/main/java/km/cd/backend/challenge/dto/response/ChallengeStatusResponse.java
+++ b/backend/src/main/java/km/cd/backend/challenge/dto/response/ChallengeStatusResponse.java
@@ -1,7 +1,7 @@
 package km.cd.backend.challenge.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.Date;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -21,10 +21,10 @@ public class ChallengeStatusResponse {
     private Integer challengePeriod;
     
     @Schema(description = "챌린지 시작일")
-    private Date startDate;
+    private LocalDate startDate;
     
     @Schema(description = "챌린지 종료일")
-    private Date endDate;
+    private LocalDate endDate;
     
     @Schema(description = "인증 시작 시간")
     private Integer certificationStartTime;

--- a/backend/src/main/java/km/cd/backend/challenge/repository/ChallengeRepository.java
+++ b/backend/src/main/java/km/cd/backend/challenge/repository/ChallengeRepository.java
@@ -1,5 +1,7 @@
 package km.cd.backend.challenge.repository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
 import km.cd.backend.challenge.domain.Challenge;
@@ -7,7 +9,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 public interface ChallengeRepository extends CrudRepository<Challenge, Long>, ChallengeCustomRepository {
-    List<Challenge> findByEndDate(Date end_date);
+    List<Challenge> findByEndDate(LocalDate endDate);
+    
+    List<Challenge> findByStartDate(LocalDate startDate);
     
     @Query("SELECT c FROM Challenge c WHERE c.challengeName = :challenge_name")
     Challenge findByChallengeName(String challenge_name);

--- a/backend/src/main/java/km/cd/backend/challenge/scheduler/ChallengeFinishScheduler.java
+++ b/backend/src/main/java/km/cd/backend/challenge/scheduler/ChallengeFinishScheduler.java
@@ -1,8 +1,11 @@
 package km.cd.backend.challenge.scheduler;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
 import km.cd.backend.challenge.domain.Challenge;
+import km.cd.backend.challenge.repository.ChallengeRepository;
 import km.cd.backend.challenge.service.ChallengeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -15,13 +18,21 @@ import org.springframework.stereotype.Component;
 public class ChallengeFinishScheduler {
 
     private final ChallengeService challengeService;
+    private final ChallengeRepository challengeRepository;
     
     @Scheduled(cron = "0 0 0 * * ?") // 초, 분, 시 일, 월, 주(요일)
     public void checkChallengeEndDate() {
-        Date currentDate = new Date();
-        List<Challenge> challengeToEnd = challengeService.findChallengesByEndDate(currentDate);
+        List<Challenge> challengeToEnd = challengeRepository.findByStartDate(LocalDate.now());
         for (Challenge challenge : challengeToEnd) {
             challengeService.finishChallenge(challenge);
+        }
+    }
+    
+    @Scheduled(cron = "0 0 0 * * ?") // 초, 분, 시 일, 월, 주(요일)
+    public void checkChallengeStartDate() {
+        List<Challenge> challengeToEnd = challengeRepository.findByStartDate(LocalDate.now());
+        for (Challenge challenge : challengeToEnd) {
+            challengeService.startChallenge(challenge);
         }
     }
 }


### PR DESCRIPTION
## 개요 :mag:

챌린지 진행 현황에 대한 필드가 필요해서 구현

### 연관된 이슈

## 작업사항 :memo:

- isEnded 필드 삭제
- String status 필드 추가 -> 아래 3가지 값만 가질 수 있음
    NOT_STARTED("진행전"),
    IN_PROGRESS("진행중"),
    COMPLETED("진행완료");
- Date -> LocalDate로 변경 -> 이제 값이 "yyyy-MM-dd" 포맷으로 저장됨
- 챌린지 시작 스케쥴러 구현 -> 매일 0시 0분마다 챌린지 체크해서 진행 상태 변경

### 스크린샷 (선택)
<img width="1456" alt="스크린샷 2024-05-16 오후 12 19 44" src="https://github.com/kookmin-sw/capstone-2024-31/assets/50860369/5ef95953-f2bc-4b96-b0e7-cf22f4f60c07">
<img width="1471" alt="스크린샷 2024-05-16 오후 12 20 18" src="https://github.com/kookmin-sw/capstone-2024-31/assets/50860369/a686a5e0-5e7d-4775-9a67-5ee5dfe727b4">

## 테스트 방법

- swagger 테스트
