### PR TITLE
[backend/feat] 신고하기 기능 구현

### DIFF
--- a/backend/src/main/java/km/cd/backend/common/error/ExceptionCode.java
+++ b/backend/src/main/java/km/cd/backend/common/error/ExceptionCode.java
@@ -11,6 +11,8 @@ public enum ExceptionCode { // 예외 발생시, body에 실어 날려줄 상태
     PARTICIPANT_NOT_FOUND_ERROR(404, "PARTICIPANT_001", "해당되는 참가자를 찾을 수 없습니다."),
     
     POST_NOT_FOUND(404, "POST_001", "해당되는 id 의 글을 찾을 수 없습니다."),
+    SAME_REPORTED_USER_ID(400, "POST_001", "사용자 ID와 작성자 ID가 동일합니다."),
+    ALREADY_REPORTED(400, "POST_002", "이미 신고한 사용자입니다."),
     
     REPLY_NOT_FOUND(404, "COMMENT_001", "해당되는 id의 댓글을 찾을 수 없습니다."),
     PARENT_COMMENT_NOT_FOUND(400, "COMMENT_002", "상위 댓글을 찾을 수 없습니다."),

--- a/backend/src/main/java/km/cd/backend/community/controller/PostController.java
+++ b/backend/src/main/java/km/cd/backend/community/controller/PostController.java
@@ -2,6 +2,7 @@ package km.cd.backend.community.controller;
 
 import km.cd.backend.community.dto.PostSimpleResponse;
 import km.cd.backend.community.dto.PostDetailResponse;
+import km.cd.backend.community.dto.ReportResponse;
 import km.cd.backend.community.service.LikeService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -80,5 +81,12 @@ public class PostController {
     likeService.unlikePost(principalDetails.getUserId(), postId);
     return ResponseEntity.ok(null);
   }
-
+  
+  @PostMapping("/{postId}/report")
+  public ResponseEntity<ReportResponse> reportPost(
+      @AuthenticationPrincipal PrincipalDetails principalDetails,
+      @PathVariable(name = "postId") Long postId
+  ) {
+    return ResponseEntity.ok(postService.reportPost(principalDetails.getUserId(), postId));
+  }
 }

--- a/backend/src/main/java/km/cd/backend/community/domain/Post.java
+++ b/backend/src/main/java/km/cd/backend/community/domain/Post.java
@@ -33,13 +33,16 @@ public class Post extends BaseTimeEntity {
   @Setter
   private String image;
 
-  private Boolean isRejected;
+  private Boolean isRejected = false;
 
   @OneToMany(mappedBy = "post", orphanRemoval = true)
   private final List<Comment> comments = new ArrayList<>();
 
   @OneToMany(mappedBy = "post", orphanRemoval = true)
   private final List<Like> likes = new ArrayList<>();
+  
+  @ElementCollection(fetch = FetchType.LAZY)
+  private List<Long> report = new ArrayList<>();
 
   @Builder
   public Post(String title, String content, Challenge challenge, User author) {

--- a/backend/src/main/java/km/cd/backend/community/dto/ReportResponse.java
+++ b/backend/src/main/java/km/cd/backend/community/dto/ReportResponse.java
@@ -1,0 +1,7 @@
+package km.cd.backend.community.dto;
+
+public record ReportResponse(
+    Integer reportingCount,
+    Boolean isRejected
+) {
+}

--- a/backend/src/main/java/km/cd/backend/community/mapper/PostMapper.java
+++ b/backend/src/main/java/km/cd/backend/community/mapper/PostMapper.java
@@ -9,6 +9,7 @@ import km.cd.backend.community.dto.CommentResponse;
 import km.cd.backend.community.dto.PostRequest;
 import km.cd.backend.community.dto.PostDetailResponse;
 import km.cd.backend.community.dto.PostSimpleResponse;
+import km.cd.backend.community.dto.ReportResponse;
 import km.cd.backend.user.domain.User;
 import km.cd.backend.user.domain.mapper.UserMapper;
 import org.mapstruct.Mapper;
@@ -47,4 +48,12 @@ public interface PostMapper {
 
   @Mapping(target = "author", source = "post.author.name")
   PostSimpleResponse entityToSimpleResponse(Post post);
+  
+  @Mapping(target = "reportingCount", source = "post", qualifiedByName = "countReports")
+  ReportResponse postToReportResponse(Post post);
+  
+  @Named("countReports")
+  default int countReports(Post post) {
+    return post.getReport().size();
+  }
 }

--- a/backend/src/main/java/km/cd/backend/community/service/PostService.java
+++ b/backend/src/main/java/km/cd/backend/community/service/PostService.java
@@ -87,8 +87,8 @@ public class PostService {
     Long authorId = post.getAuthor().getId();
     List<Long> reportingUser = post.getReport();
     
-    if (userId.equals(authorId)) throw new CustomException(ExceptionCode.POST_NOT_FOUND);
-    if (reportingUser.contains(userId)) throw new CustomException(ExceptionCode.POST_NOT_FOUND);
+    if (userId.equals(authorId)) throw new CustomException(ExceptionCode.SAME_REPORTED_USER_ID);
+    if (reportingUser.contains(userId)) throw new CustomException(ExceptionCode.ALREADY_REPORTED);
     
     reportingUser.add(userId);
     


### PR DESCRIPTION
## 개요 :mag:

게시물 인증이 제대로 되지 않았다 판단되었을 때, 게시글을 신고할 수 있는 기능.

### 연관된 이슈

## 작업사항 :memo:

- 신고 기능 -> 5명 이상이 신고하면 post의 isRejected 필드가 true가 되어서 인증 카운트 안 됨 !
(추후에 구체적인 기준으로 변경)

### 스크린샷 (선택)
### Deletemapping으로 아래 스크린샷에 되어있는데 Postmapping으로 바꿔놓았습니다. 
<img width="1462" alt="스크린샷 2024-05-16 오후 2 15 31" src="https://github.com/kookmin-sw/capstone-2024-31/assets/50860369/393491a7-13d6-4ca5-aa7a-3aa1a253bdfa">

## 테스트 방법

- swagger에서 확인 가능
