### PR TITLE
[backend/fix] get method는 requestBody를 지원하지 않아서 post 요청으로 변경

### DIFF
--- a/backend/src/main/java/km/cd/backend/challenge/controller/ChallengeController.java
+++ b/backend/src/main/java/km/cd/backend/challenge/controller/ChallengeController.java
@@ -48,7 +48,7 @@ public class ChallengeController {
         return ResponseEntity.ok(saved.getId());
     }
 
-    @GetMapping("/list")
+    @PostMapping("/list")
     public ResponseEntity<List<ChallengeSimpleResponse>> getAllChallenge(
         @RequestParam(name = "cursorId", required = false, defaultValue = "0") Long cursorId,
         @RequestParam(name = "size", required = false, defaultValue = "5") int size,


### PR DESCRIPTION
## 개요 :mag:

org.springframework.http.converter.HttpMessageNotReadableException: Required request body is missing: 에러 발생

### 연관된 이슈

## 작업사항 :memo:

- get method는 requestBody를 지원하지 않아서 post 요청으로 변경

### 스크린샷 (선택)
<img width="1555" alt="스크린샷 2024-05-16 오후 7 57 23" src="https://github.com/kookmin-sw/capstone-2024-31/assets/50860369/fd0010ca-736e-41d9-89a8-1e56b476158b">

## 테스트 방법

- swagger test
