### PR TITLE
[All/feature] 비공개 챌린지 암호코드 확인 과정 구현

### DIFF
--- a/frontend/lib/challenge/search/challenge_search_screen.dart
+++ b/frontend/lib/challenge/search/challenge_search_screen.dart
@@ -34,7 +34,6 @@ class _ChallengeSearchScreenState extends State<ChallengeSearchScreen> {
   bool hasMoreData = true;
   final ScrollController _scrollController = ScrollController();
 
-
   void _getFilteredChallengeList(bool isFiltered) async {
     if (!hasMoreData) return;
 
@@ -45,7 +44,7 @@ class _ChallengeSearchScreenState extends State<ChallengeSearchScreen> {
     dio.options.headers['Authorization'] =
     'Bearer ${prefs.getString('access_token')}';
 
-    Map<String, dynamic> filter = {};
+    Map<String, dynamic> filter = {}; // Initialize filter with an empty map
 
     try {
       if (isFiltered) {
@@ -59,21 +58,21 @@ class _ChallengeSearchScreenState extends State<ChallengeSearchScreen> {
       } else {
         filter = ChallengeFilter(
             name: searchValue,
+            isPrivate: null,
             category: selectedIndex == 0
                 ? null
                 : ChallengeCategory.values[selectedIndex - 1])
             .toJson();
+
       }
       logger.d("challenge filter: $filter");
 
-      final response = await dio.get(
-        '${Env.serverUrl}/challenges/list',
-        queryParameters: {
-          'cursor': currentCursor,
-          'size': pageSize,
-          ...filter, // Add filter parameters to query parameters
-        },
-      );
+      final response = await dio.post('${Env.serverUrl}/challenges/list',
+          data: filter,
+          queryParameters: {
+            'cursor': currentCursor,
+            'size': pageSize,
+          });
 
       if (response.statusCode == 200) {
         logger.d(response.data);
@@ -83,6 +82,10 @@ class _ChallengeSearchScreenState extends State<ChallengeSearchScreen> {
 
         setState(() {
           if (newData.isNotEmpty) {
+            if (!_isPrivate) {
+              newData =
+                  newData.toList();
+            }
             challengeList.addAll(newData);
             currentCursor = challengeList.last.id;
           } else {
@@ -96,7 +99,6 @@ class _ChallengeSearchScreenState extends State<ChallengeSearchScreen> {
       logger.d(e.toString());
     }
   }
-
 
   @override
   void initState() {
@@ -182,17 +184,17 @@ class _ChallengeSearchScreenState extends State<ChallengeSearchScreen> {
                   const SizedBox(height: 5),
                   Expanded(
                       child: GridView.builder(
-                    controller: _scrollController,
-                    gridDelegate:
+                        controller: _scrollController,
+                        gridDelegate:
                         const SliverGridDelegateWithFixedCrossAxisCount(
-                      crossAxisCount: 2,
-                      childAspectRatio: 1 / 1.4,
-                    ),
-                    itemCount: challengeList.length,
-                    itemBuilder: (context, index) {
-                      return ChallengeItemCard(data: challengeList[index]);
-                    },
-                  ))
+                          crossAxisCount: 2,
+                          childAspectRatio: 1 / 1.4,
+                        ),
+                        itemCount: challengeList.length,
+                        itemBuilder: (context, index) {
+                          return ChallengeItemCard(data: challengeList[index]);
+                        },
+                      ))
                 ])));
   }
 
@@ -205,7 +207,7 @@ class _ChallengeSearchScreenState extends State<ChallengeSearchScreen> {
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: List.generate(
                   categoryList.length,
-                  (index) => Padding(
+                      (index) => Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 4),
                       child: ElevatedButton(
                         onPressed: () {
@@ -223,7 +225,7 @@ class _ChallengeSearchScreenState extends State<ChallengeSearchScreen> {
                         },
                         style: ButtonStyle(
                           padding:
-                              MaterialStateProperty.all<EdgeInsetsGeometry?>(
+                          MaterialStateProperty.all<EdgeInsetsGeometry?>(
                             const EdgeInsets.symmetric(horizontal: 15),
                           ),
                           maximumSize: MaterialStateProperty.all<Size>(
@@ -238,7 +240,7 @@ class _ChallengeSearchScreenState extends State<ChallengeSearchScreen> {
                           ),
                           backgroundColor: selectedIndex == index
                               ? MaterialStateProperty.all<Color>(
-                                  Palette.purPle400)
+                              Palette.purPle400)
                               : null,
                         ),
                         child: Text(categoryList[index],

--- a/frontend/lib/main/bottom_tabs/home/home_components/home_challenge_list.dart
+++ b/frontend/lib/main/bottom_tabs/home/home_components/home_challenge_list.dart
@@ -91,7 +91,7 @@ class _ChallengeItemListState extends State<ChallengeItemList> {
           ...responseIsprivateFalse.data as List,
           ...responseIsprivateTrue.data as List
         ];
-        logger.d(combinedData);
+        logger.d("홈챌린지 리스트 : $combinedData");
 
         return combinedData.map((c) => ChallengeSimple.fromJson(c)).toList();
       }

--- a/frontend/lib/main/bottom_tabs/home/home_components/privateCode_input_dialog.dart
+++ b/frontend/lib/main/bottom_tabs/home/home_components/privateCode_input_dialog.dart
@@ -32,6 +32,7 @@ class _PasswordInputDialogState extends State<PasswordInputDialog> {
       color: color);
 
   Future<bool> _fetchChallenge(String inputCode) async {
+    bool canAccess = false;
     SharedPreferences prefs = await SharedPreferences.getInstance();
     Dio dio = Dio();
     dio.options.headers['content-Type'] = 'application/json';
@@ -46,17 +47,17 @@ class _PasswordInputDialogState extends State<PasswordInputDialog> {
       if (response.statusCode == 200) {
         logger.d('$inputCode : ${response.data}코드 일치');
         logger.d(response.data);
-        isPossibleJoin = true;
-      } else if (response.statusCode == 403) {
+        canAccess = true;
+      } else if (response.statusCode == 404) {
         logger.d('코드 불일치');
         logger.d(response.data);
-        isPossibleJoin = false;
+        canAccess = false;
       }
     } catch (e) {
       logger.e(e);
     }
 
-    return isPossibleJoin;
+    return canAccess;
   }
 
   @override
@@ -64,6 +65,12 @@ class _PasswordInputDialogState extends State<PasswordInputDialog> {
     super.initState();
     _passwordController = TextEditingController();
     _confirmPasswordController = TextEditingController();
+
+    _fetchChallenge("아무거나101010101").then((value) => setState(() {
+      Get.snackbar("챌린지 생성자", "암호코드 없이 입장");
+      Get.to(() => ChallengeDetailScreen(
+          challengeId: widget.challengeId, isFromMainScreen: true));
+    })); //c챌린지 생성자인지 확인 용.
   }
 
   @override

--- a/frontend/lib/main/bottom_tabs/myRoutineUp/my_routine_up_screen.dart
+++ b/frontend/lib/main/bottom_tabs/myRoutineUp/my_routine_up_screen.dart
@@ -5,6 +5,7 @@ import 'package:frontend/model/config/palette.dart';
 import 'package:frontend/model/controller/user_controller.dart';
 import 'package:frontend/model/data/challenge/challenge_simple.dart';
 import 'package:get/get.dart';
+import 'package:logger/logger.dart';
 
 class MyRoutineUpScreen extends StatefulWidget {
   const MyRoutineUpScreen({super.key});
@@ -20,6 +21,8 @@ class _MyRoutineUpScreenState extends State<MyRoutineUpScreen> {
   List<ChallengeSimple> ingChallenge = [];
   List<ChallengeSimple> endChallenge = [];
 
+  Logger logger = Logger();
+
   List<int> _getProgressNumber() {
     return [beforeChallenge.length, ingChallenge.length, endChallenge.length];
   }
@@ -27,8 +30,12 @@ class _MyRoutineUpScreenState extends State<MyRoutineUpScreen> {
   @override
   void initState() {
     super.initState();
-    for (var challenge in controller.myChallenges) {
+    logger.d("controller : ${controller}");
 
+    logger.d("controller.myChallenges : ${controller.myChallenges}");
+
+
+    for (var challenge in controller.myChallenges) {
       if (challenge.status == "진행전") {
         beforeChallenge.add(challenge);
       } else if (challenge.status == "진행중") {

--- a/frontend/lib/model/data/challenge/challenge_filter.dart
+++ b/frontend/lib/model/data/challenge/challenge_filter.dart
@@ -20,7 +20,7 @@ class ChallengeFilter {
     );
   }
 
-  // 객체에서 JSON으로 변환
+
   Map<String, dynamic> toJson() {
     return {
       'name': name,
@@ -28,4 +28,5 @@ class ChallengeFilter {
       'category': category?.toJson(),
     };
   }
+
 }


### PR DESCRIPTION
## 개요 :mag:

비공개 챌린지 암호코드 확인 과정 구현했습니다. 
챌린지 생성자는 암호코드없이 바로 입장함 -> "인증코드 없이 입장합니다." 메시지를 통해 바로 입장한 것을 알림.

### 연관된 이슈

## 작업사항 :memo:

현재 본인이 만든 챌린지로 실험해야됐어서, 암호코드 잘못 입력해도 입장하게 되는게 오류인줄 알았움(3시간 헤맴..)
나중에 타인이 만든걸로 실험해봐야함.
