### PR TITLE
[backend/feat] 유저 response 카테고리 필드 추가 및 챌린지 상태 에러 변경

### DIFF
--- a/backend/src/main/java/km/cd/backend/challenge/service/ChallengeService.java
+++ b/backend/src/main/java/km/cd/backend/challenge/service/ChallengeService.java
@@ -61,8 +61,9 @@ public class ChallengeService {
         Challenge challenge = ChallengeMapper.INSTANCE.requestToEntity(challengeCreateRequest);
         
         // 챌린지 상태 설정
+        boolean isProgress = challenge.getStartDate().isEqual(LocalDate.now()) || challenge.getStartDate().isBefore(LocalDate.now());
         challenge.setStatus(
-            challenge.getStartDate().isBefore(LocalDate.now()) ?
+            isProgress ?
                 ChallengeStatus.IN_PROGRESS.getDescription() :
                 ChallengeStatus.NOT_STARTED.getDescription()
         );

--- a/backend/src/main/java/km/cd/backend/user/dto/UserResponse.java
+++ b/backend/src/main/java/km/cd/backend/user/dto/UserResponse.java
@@ -1,9 +1,14 @@
 package km.cd.backend.user.dto;
 
+import java.util.List;
+import km.cd.backend.challenge.domain.ChallengeCategory;
+
 public record UserResponse(
         Long id,
         String email,
         String avatar,
         String name,
-        int point
+        int point,
+        List<ChallengeCategory> categories
+        
 ){ }


### PR DESCRIPTION
## 개요 :mag:

이슈 #1 유저정보 조회할 때는 카테고리 필드가 없어유 
이슈 #2 당일이 챌린지 시작일인데 status가 아직 "진행전"이무니다. 확인 부탁스

### 연관된 이슈

## 작업사항 :memo:

- 유저 response dto에 카테고리 필드 추가
- 챌린지 상태 저장할 때, isEqual로 오늘인지도 체크

### 스크린샷 (선택)
## 카테고리 필드 추가
<img width="861" alt="스크린샷 2024-05-17 오전 9 31 45" src="https://github.com/kookmin-sw/capstone-2024-31/assets/50860369/b1f974ea-1650-4146-9e53-a2069dc45f04">

## 챌린지 상태 수정
<img width="856" alt="스크린샷 2024-05-17 오전 9 30 27" src="https://github.com/kookmin-sw/capstone-2024-31/assets/50860369/28423580-db75-47ea-8dd4-9339a4c80ef3">

## 테스트 방법

- swagger test

