### PR TITLE
[backend/feat] DataSeeder를 활용한 더미 데이터 생성 및 받아오는 API 개발

### DIFF
--- a/backend/src/main/java/km/cd/backend/challenge/controller/ChallengeController.java
+++ b/backend/src/main/java/km/cd/backend/challenge/controller/ChallengeController.java
@@ -58,6 +58,11 @@ public class ChallengeController {
         return ResponseEntity.ok(challenges);
     }
     
+    @GetMapping("/list")
+    public ResponseEntity<List<ChallengeInformationResponse>> getAllChallenge() {
+        return ResponseEntity.ok(challengeService.getAllChallenge());
+    }
+    
 
     @GetMapping("/{challengeId}")
     public ResponseEntity<ChallengeInformationResponse> getChallenge(

--- a/backend/src/main/java/km/cd/backend/challenge/service/ChallengeService.java
+++ b/backend/src/main/java/km/cd/backend/challenge/service/ChallengeService.java
@@ -1,6 +1,7 @@
 package km.cd.backend.challenge.service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 import java.util.Optional;
@@ -190,6 +191,17 @@ public class ChallengeService {
         List<Challenge> challenges = challengeRepository.findByChallengeWithFilterAndPaging(cursorId, size, filter);
 
         return challenges.stream().map(ChallengeMapper.INSTANCE::entityToSimpleResponse).toList();
+    }
+    
+    public List<ChallengeInformationResponse> getAllChallenge() {
+        Iterable<Challenge> challenges = challengeRepository.findAll();
+        List<ChallengeInformationResponse> responses = new ArrayList<>();
+        
+        for (Challenge challenge : challenges) {
+            responses.add(ChallengeMapper.INSTANCE.challengeToChallengeResponse(challenge));
+        }
+        
+        return responses;
     }
     
     public List<ParticipantResponse> getParticipant(Long challengeId) {

--- a/backend/src/main/java/km/cd/backend/common/utils/ChallengeDataSeeder.java
+++ b/backend/src/main/java/km/cd/backend/common/utils/ChallengeDataSeeder.java
@@ -1,0 +1,124 @@
+package km.cd.backend.common.utils;
+
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import km.cd.backend.certification.domain.CertificationType;
+import km.cd.backend.challenge.domain.Challenge;
+import km.cd.backend.challenge.domain.ChallengeCategory;
+import km.cd.backend.challenge.dto.enums.ChallengeFrequency;
+import km.cd.backend.challenge.dto.enums.ChallengeStatus;
+import km.cd.backend.challenge.repository.ChallengeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChallengeDataSeeder implements CommandLineRunner {
+    
+    @Autowired
+    private ChallengeRepository challengeRepository;
+    
+    @Override
+    public void run(String... args) throws Exception {
+        Challenge privateChallenge1 = Challenge.builder()
+            .isPrivate(true)
+            .privateCode("1234")
+            .challengeName("혁규의 1일 1헬스")
+            .challengeExplanation("헬스 is my life")
+            .challengePeriod(3)
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now().plusDays(21))
+            .certificationFrequency(ChallengeFrequency.EVERY_DAY.getFrequency())
+            .certificationStartTime(1)
+            .certificationEndTime(24)
+            .certificationExplanation("손 인증으로 합니다 ~")
+            .isGalleryPossible(false)
+            .maximumPeople(25)
+            .challengeImagePaths(Arrays.asList("https://routineup-s3.s3.ap-northeast-2.amazonaws.com/challenges/008e838c-256f-4803-a272-5a0c6977f609"))
+            .failedVerificationImage("https://routineup-s3.s3.ap-northeast-2.amazonaws.com/challenges/008e838c-256f-4803-a272-5a0c6977f609")
+            .successfulVerificationImage("https://routineup-s3.s3.ap-northeast-2.amazonaws.com/challenges/008e838c-256f-4803-a272-5a0c6977f609")
+            .status(ChallengeStatus.IN_PROGRESS.getDescription())
+            .certificationType(CertificationType.HAND_GESTURE)
+            .challengeCategory(ChallengeCategory.EXCERCISE)
+            .totalCertificationCount(21)
+            .build();
+        
+        Challenge privateChallenge2 = Challenge.builder()
+            .isPrivate(true)
+            .privateCode("1234")
+            .challengeName("석주의 커밋 도전기")
+            .challengeExplanation("난 네이버 사장이 되겠어")
+            .challengePeriod(5)
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now().plusDays(35))
+            .certificationFrequency(ChallengeFrequency.EVERY_4TH_WEEK.getFrequency())
+            .certificationStartTime(0)
+            .certificationEndTime(24)
+            .certificationExplanation("github 커밋 인증으로 합니다 ~")
+            .isGalleryPossible(false)
+            .maximumPeople(4)
+            .challengeImagePaths(Arrays.asList("https://routineup-s3.s3.ap-northeast-2.amazonaws.com/challenges/008e838c-256f-4803-a272-5a0c6977f609"))
+            .failedVerificationImage("https://routineup-s3.s3.ap-northeast-2.amazonaws.com/challenges/008e838c-256f-4803-a272-5a0c6977f609")
+            .successfulVerificationImage("https://routineup-s3.s3.ap-northeast-2.amazonaws.com/challenges/008e838c-256f-4803-a272-5a0c6977f609")
+            .status(ChallengeStatus.IN_PROGRESS.getDescription())
+            .certificationType(CertificationType.GITHUB_COMMIT)
+            .challengeCategory(ChallengeCategory.STUDY)
+            .totalCertificationCount(35)
+            .build();
+        
+        // 공개 챌린지 2개 생성
+        Challenge publicChallenge1 = Challenge.builder()
+            .isPrivate(false)
+            .challengeName("혜은이랑 같이 수영하실 분 ~ ㅋ")
+            .challengeExplanation("혜은이는 수영 잘하지롱 ㅋ")
+            .challengePeriod(2)
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now().plusDays(14))
+            .certificationFrequency(ChallengeFrequency.EVERY_3RD_WEEK.getFrequency())
+            .certificationStartTime(0)
+            .certificationEndTime(24)
+            .certificationExplanation("손 인증으로 합니다 ~")
+            .isGalleryPossible(true)
+            .maximumPeople(100)
+            .challengeImagePaths(Arrays.asList("https://routineup-s3.s3.ap-northeast-2.amazonaws.com/challenges/008e838c-256f-4803-a272-5a0c6977f609"))
+            .failedVerificationImage("https://routineup-s3.s3.ap-northeast-2.amazonaws.com/challenges/008e838c-256f-4803-a272-5a0c6977f609")
+            .successfulVerificationImage("https://routineup-s3.s3.ap-northeast-2.amazonaws.com/challenges/008e838c-256f-4803-a272-5a0c6977f609")
+            .status(ChallengeStatus.IN_PROGRESS.getDescription())
+            .certificationType(CertificationType.HAND_GESTURE)
+            .challengeCategory(ChallengeCategory.EXCERCISE)
+            .totalCertificationCount(14)
+            .build();
+        
+        Challenge publicChallenge2 = Challenge.builder()
+            .isPrivate(false)
+            .challengeName("채환이는 닭가슴살을 좋아해")
+            .challengeExplanation("닭가슬살 패실 분 구함")
+            .challengePeriod(6)
+            .startDate(LocalDate.now())
+            .endDate(LocalDate.now().plusDays(42))
+            .certificationFrequency(ChallengeFrequency.EVERY_5TH_WEEK.getFrequency())
+            .certificationStartTime(0)
+            .certificationEndTime(24)
+            .certificationExplanation("손 인증으로 합니다 ~")
+            .isGalleryPossible(false)
+            .maximumPeople(1000)
+            .challengeImagePaths(Arrays.asList("https://routineup-s3.s3.ap-northeast-2.amazonaws.com/challenges/008e838c-256f-4803-a272-5a0c6977f609"))
+            .failedVerificationImage("https://routineup-s3.s3.ap-northeast-2.amazonaws.com/challenges/008e838c-256f-4803-a272-5a0c6977f609")
+            .successfulVerificationImage("https://routineup-s3.s3.ap-northeast-2.amazonaws.com/challenges/008e838c-256f-4803-a272-5a0c6977f609")
+            .status(ChallengeStatus.IN_PROGRESS.getDescription())
+            .certificationType(CertificationType.HAND_GESTURE)
+            .challengeCategory(ChallengeCategory.EATING)
+            .totalCertificationCount(42)
+            .build();
+        
+        // 데이터 저장
+        challengeRepository.save(privateChallenge1);
+        challengeRepository.save(privateChallenge2);
+        challengeRepository.save(publicChallenge1);
+        challengeRepository.save(publicChallenge2);
+        
+        // 출력 확인
+        System.out.println("Challenges initialized");
+    }
+}

--- a/frontend/lib/community/community_screen.dart
+++ b/frontend/lib/community/community_screen.dart
@@ -5,6 +5,12 @@ import 'package:frontend/main/main_screen.dart';
 import 'package:frontend/model/config/palette.dart';
 import 'package:frontend/main/bottom_tabs/home/home_screen.dart';
 import 'package:get/get.dart';
+import 'dart:io';
+import 'package:frontend/model/data/post.dart';
+import 'package:flutter/services.dart';
+import 'package:logger/logger.dart';
+import 'package:dio/dio.dart' as dio;
+import 'package:shared_preferences/shared_preferences.dart';
 
 class CommunityScreen extends StatefulWidget {
   const CommunityScreen({super.key, this.isFromCreatePostingScreen = false});
@@ -17,10 +23,40 @@ class CommunityScreen extends StatefulWidget {
 
 class _CommunityScreenState extends State<CommunityScreen>
     with TickerProviderStateMixin {
+  final logger = Logger();
+
   int _selectedIndex = 0; // 탭 인덱스
   int _sortIndex = 0; // 정렬 방식 인덱스
 
   late TabController _tabController;
+
+  Future<List<SimplePost>> getPostsForChallenge(int challengeId) async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    dio.Dio dioInstance = dio.Dio();
+
+    dioInstance.options.headers['Authorization'] =
+    'Bearer ${prefs.getString('access_token')}';
+
+    try {
+      final response = await dioInstance.get('/challenges/$challengeId/posts');
+
+      if (response.statusCode == 200) {
+        List<SimplePost> posts = (response.data as List)
+            .map((post) => SimplePost.fromJson(post))
+            .toList();
+        return posts;
+      } else if (response.statusCode == 404) {
+        // 404 Not Found 에러 처리
+        throw Exception("해당 챌린지의 게시물을 찾을 수 없습니다.");
+      } else {
+        // 기타 에러 처리
+        throw Exception("게시물 가져오기 실패: ${response.statusCode}");
+      }
+    } catch (e) {
+      logger.e("게시물 가져오는 중 에러 발생: $e");
+      rethrow;
+    }
+  }
 
   @override
   void initState() {

--- a/frontend/lib/model/data/createdPost.dart
+++ b/frontend/lib/model/data/createdPost.dart
@@ -1,0 +1,114 @@
+class CreatedpostPost {
+  final int id;
+  final String title;
+  final String content;
+  final Author author;
+  final String image;
+  final DateTime createdDate;
+  final List<Comment> comments;
+
+  CreatedpostPost({
+    required this.id,
+    required this.title,
+    required this.content,
+    required this.author,
+    required this.image,
+    required this.createdDate,
+    required this.comments,
+  });
+
+  factory CreatedpostPost.fromJson(Map<String, dynamic> json) {
+    return CreatedpostPost(
+      id: json['id'] as int,
+      title: json['title'] as String,
+      content: json['content'] as String,
+      author: Author.fromJson(json['author'] as Map<String, dynamic>),
+      image: json['image'] as String,
+      createdDate: DateTime.parse(json['createdDate'] as String),
+      comments: (json['comments'] as List<dynamic>)
+          .map((commentJson) => Comment.fromJson(commentJson as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+class Author {
+  final int id;
+  final String email;
+  final String avatar;
+  final String name;
+  final int point;
+  final List<String> categories;
+
+  Author({
+    required this.id,
+    required this.email,
+    required this.avatar,
+    required this.name,
+    required this.point,
+    required this.categories,
+  });
+
+  factory Author.fromJson(Map<String, dynamic> json) {
+    return Author(
+      id: json['id'] as int,
+      email: json['email'] as String,
+      avatar: json['avatar'] as String,
+      name: json['name'] as String,
+      point: json['point'] as int,
+      categories: (json['categories'] as List<dynamic>).map((category) => category as String).toList(),
+    );
+  }
+}
+
+class Comment {
+  final int id;
+  final String author;
+  final String content;
+  final UserResponse userResponse;
+
+  Comment({
+    required this.id,
+    required this.author,
+    required this.content,
+    required this.userResponse,
+  });
+
+  factory Comment.fromJson(Map<String, dynamic> json) {
+    return Comment(
+      id: json['id'] as int,
+      author: json['author'] as String,
+      content: json['content'] as String,
+      userResponse: UserResponse.fromJson(json['userResponse'] as Map<String, dynamic>),
+    );
+  }
+}
+
+class UserResponse {
+  final int id;
+  final String email;
+  final String avatar;
+  final String name;
+  final int point;
+  final List<String> categories;
+
+  UserResponse({
+    required this.id,
+    required this.email,
+    required this.avatar,
+    required this.name,
+    required this.point,
+    required this.categories,
+  });
+
+  factory UserResponse.fromJson(Map<String, dynamic> json) {
+    return UserResponse(
+      id: json['id'] as int,
+      email: json['email'] as String,
+      avatar: json['avatar'] as String,
+      name: json['name'] as String,
+      point: json['point'] as int,
+      categories: (json['categories'] as List<dynamic>).map((category) => category as String).toList(),
+    );
+  }
+}

--- a/frontend/lib/model/data/post.dart
+++ b/frontend/lib/model/data/post.dart
@@ -1,3 +1,23 @@
+class SimplePost {
+  final int id;
+  final String title;
+  final String author;
+
+  SimplePost({
+    required this.id,
+    required this.title,
+    required this.author,
+  });
+
+  factory SimplePost.fromJson(Map<String, dynamic> json) {
+    return SimplePost(
+      id: json['id'] as int,
+      title: json['title'] as String,
+      author: json['author'] as String,
+    );
+  }
+}
+
 class Author {
   final int id;
   final String email;


### PR DESCRIPTION
## 개요 :mag:

프론트 요청에 따른 더미데이터 생성

### 연관된 이슈

## 작업사항 :memo:

- DataSeeder를 활용한 더미 데이터 생성 및 받아오는 API 개발

### 스크린샷 (선택)
<img width="1515" alt="스크린샷 2024-05-17 오후 4 26 54" src="https://github.com/kookmin-sw/capstone-2024-31/assets/50860369/7893a9d1-ee0c-4951-b509-395b1df7d418">

## 테스트 방법

- swagger test
