### PR TITLE
[all] detail_screen null 에러 해결

### DIFF
--- a/frontend/lib/challenge/detail/detail_challenge_screen.dart
+++ b/frontend/lib/challenge/detail/detail_challenge_screen.dart
@@ -48,7 +48,7 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
     try {
       logger.d(widget.challengeId);
       final response = await dio.get(
-          '${Env.serverUrl}/challenges/${widget.challengeId}/detail',
+          '${Env.serverUrl}/challenges/${widget.challengeId}',
       );
       if (response.statusCode == 200) {
         logger.d('챌린지 디테일 조회 성공');
@@ -145,7 +145,7 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
           ? null
           : isLoading
               ? const Center(child: CircularProgressIndicator())
-              : buildChallengeDetailBottomNavigationBar(context, challenge!),
+              : buildChallengeDetailBottomNavigationBar(context, challenge ?? Challenge.getDummyData()),
     );
   }
 

--- a/frontend/lib/challenge/detail/detail_challenge_screen.dart
+++ b/frontend/lib/challenge/detail/detail_challenge_screen.dart
@@ -48,8 +48,8 @@ class _ChallengeDetailScreenState extends State<ChallengeDetailScreen> {
     try {
       logger.d(widget.challengeId);
       final response = await dio.get(
-          '${Env.serverUrl}/challenges/${widget.challengeId}',
-          queryParameters: {"code": ""});
+          '${Env.serverUrl}/challenges/${widget.challengeId}/detail',
+      );
       if (response.statusCode == 200) {
         logger.d('챌린지 디테일 조회 성공');
         logger.d(response.data);

--- a/frontend/lib/challenge/join/join_challenge_screen.dart
+++ b/frontend/lib/challenge/join/join_challenge_screen.dart
@@ -22,10 +22,6 @@ class JoinChallengeScreen extends StatefulWidget {
 class _JoinChallengeScreenState extends State<JoinChallengeScreen> {
   bool showVerificationInput = false;
   bool isCheckedAll = false;
-  bool _isCheckChallengeInform = false;
-  bool _isCheckPersonalInform = false;
-  bool _isCheckJoin = false;
-
   List<bool> isCheckList = [false, false, false];
 
   @override
@@ -51,7 +47,7 @@ class _JoinChallengeScreenState extends State<JoinChallengeScreen> {
         ),
         body: SingleChildScrollView(
           child: Padding(
-              padding: EdgeInsets.symmetric(vertical: 10, horizontal: 15),
+              padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 15),
               child: Column(
                 children: [
                   PhotoesWidget(

--- a/frontend/lib/challenge/search/challenge_search_screen.dart
+++ b/frontend/lib/challenge/search/challenge_search_screen.dart
@@ -13,7 +13,9 @@ import 'package:logger/logger.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class ChallengeSearchScreen extends StatefulWidget {
-  const ChallengeSearchScreen({super.key});
+  const ChallengeSearchScreen({super.key, this.enterSelectIndex});
+
+  final int? enterSelectIndex;
 
   @override
   State<ChallengeSearchScreen> createState() => _ChallengeSearchScreenState();
@@ -25,9 +27,9 @@ class _ChallengeSearchScreenState extends State<ChallengeSearchScreen> {
   List<String> categoryList =
       ['전체'] + ChallengeCategory.values.map((e) => e.name).toList();
   String searchValue = '';
-  int selectedIndex = 0;
   bool _isPrivate = false;
   List<ChallengeSimple> challengeList = [];
+  late int selectedIndex;
 
   int currentCursor = 0;
   final int pageSize = 10;
@@ -42,28 +44,27 @@ class _ChallengeSearchScreenState extends State<ChallengeSearchScreen> {
 
     dio.options.headers['content-Type'] = 'application/json';
     dio.options.headers['Authorization'] =
-    'Bearer ${prefs.getString('access_token')}';
+        'Bearer ${prefs.getString('access_token')}';
 
     Map<String, dynamic> filter = {}; // Initialize filter with an empty map
 
     try {
       if (isFiltered) {
         filter = ChallengeFilter(
-            name: searchValue,
-            isPrivate: _isPrivate,
-            category: selectedIndex == 0
-                ? null
-                : ChallengeCategory.values[selectedIndex - 1])
+                name: searchValue,
+                isPrivate: _isPrivate,
+                category: selectedIndex == 0
+                    ? null
+                    : ChallengeCategory.values[selectedIndex - 1])
             .toJson();
       } else {
         filter = ChallengeFilter(
-            name: searchValue,
-            isPrivate: null,
-            category: selectedIndex == 0
-                ? null
-                : ChallengeCategory.values[selectedIndex - 1])
+                name: searchValue,
+                isPrivate: null,
+                category: selectedIndex == 0
+                    ? null
+                    : ChallengeCategory.values[selectedIndex - 1])
             .toJson();
-
       }
       logger.d("challenge filter: $filter");
 
@@ -83,8 +84,7 @@ class _ChallengeSearchScreenState extends State<ChallengeSearchScreen> {
         setState(() {
           if (newData.isNotEmpty) {
             if (!_isPrivate) {
-              newData =
-                  newData.toList();
+              newData = newData.toList();
             }
             challengeList.addAll(newData);
             currentCursor = challengeList.last.id;
@@ -103,6 +103,9 @@ class _ChallengeSearchScreenState extends State<ChallengeSearchScreen> {
   @override
   void initState() {
     super.initState();
+
+    selectedIndex = widget.enterSelectIndex ?? 0;
+
     _getFilteredChallengeList(false); // 초기 데이터 로드  viewFilter = false
     _scrollController.addListener(() {
       if (_scrollController.position.pixels ==
@@ -184,17 +187,17 @@ class _ChallengeSearchScreenState extends State<ChallengeSearchScreen> {
                   const SizedBox(height: 5),
                   Expanded(
                       child: GridView.builder(
-                        controller: _scrollController,
-                        gridDelegate:
+                    controller: _scrollController,
+                    gridDelegate:
                         const SliverGridDelegateWithFixedCrossAxisCount(
-                          crossAxisCount: 2,
-                          childAspectRatio: 1 / 1.4,
-                        ),
-                        itemCount: challengeList.length,
-                        itemBuilder: (context, index) {
-                          return ChallengeItemCard(data: challengeList[index]);
-                        },
-                      ))
+                      crossAxisCount: 2,
+                      childAspectRatio: 1 / 1.4,
+                    ),
+                    itemCount: challengeList.length,
+                    itemBuilder: (context, index) {
+                      return ChallengeItemCard(data: challengeList[index]);
+                    },
+                  ))
                 ])));
   }
 
@@ -207,7 +210,7 @@ class _ChallengeSearchScreenState extends State<ChallengeSearchScreen> {
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: List.generate(
                   categoryList.length,
-                      (index) => Padding(
+                  (index) => Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 4),
                       child: ElevatedButton(
                         onPressed: () {
@@ -225,7 +228,7 @@ class _ChallengeSearchScreenState extends State<ChallengeSearchScreen> {
                         },
                         style: ButtonStyle(
                           padding:
-                          MaterialStateProperty.all<EdgeInsetsGeometry?>(
+                              MaterialStateProperty.all<EdgeInsetsGeometry?>(
                             const EdgeInsets.symmetric(horizontal: 15),
                           ),
                           maximumSize: MaterialStateProperty.all<Size>(
@@ -240,7 +243,7 @@ class _ChallengeSearchScreenState extends State<ChallengeSearchScreen> {
                           ),
                           backgroundColor: selectedIndex == index
                               ? MaterialStateProperty.all<Color>(
-                              Palette.purPle400)
+                                  Palette.purPle400)
                               : null,
                         ),
                         child: Text(categoryList[index],

--- a/frontend/lib/main/bottom_tabs/home/home_components/home_category_component.dart
+++ b/frontend/lib/main/bottom_tabs/home/home_components/home_category_component.dart
@@ -2,41 +2,13 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:frontend/challenge/search/challenge_search_screen.dart';
 import 'package:frontend/model/config/palette.dart';
+import 'package:frontend/model/config/category_card_list.dart';
+import 'package:get/get.dart';
+
 
 class HomeCategory extends StatelessWidget {
-  final List<Map<String, dynamic>> categoryList = [
-    {
-      "name": "운동",
-      "memo": "튼튼한 몸을 위하여!",
-      "icons": "assets/icons/category_icons/exercise.svg",
-      "color": const Color(0xffEEE9FD),
-    },
-    {
-      "name": "식습관",
-      "memo": "골고루 건강하게!",
-      "icons": "assets/icons/category_icons/eating.svg",
-      "color": const Color(0xffFFDFDF),
-    },
-    {
-      "name": "취미",
-      "memo": "더 즐거운 삶을 위해!",
-      "icons": "assets/icons/category_icons/hobby.svg",
-      "color": const Color(0xffFFD0A3),
-    },
-    {
-      "name": "환경",
-      "memo": "깨끗한 환경에서!",
-      "icons": "assets/icons/category_icons/nature.svg",
-      "color": const Color(0xffDAF2CB),
-    },
-    {
-      "name": "공부",
-      "memo": "지적인 나를 위해!",
-      "icons": "assets/icons/category_icons/study.svg",
-      "color": const Color(0xffD4E0FF),
-    }
-  ];
 
   @override
   Widget build(BuildContext context) {
@@ -91,6 +63,10 @@ class CategoryCard extends StatelessWidget {
     return GestureDetector(
         onTap: () {
           print("$name 카테고리 클릭됨");
+          int index = categoryList.indexWhere((category) => category['name'] == name);
+
+          Get.to(ChallengeSearchScreen(enterSelectIndex: index+1));
+
         },
         child: Container(
             padding: const EdgeInsets.all(0),

--- a/frontend/lib/main/bottom_tabs/home/home_components/home_category_component.dart
+++ b/frontend/lib/main/bottom_tabs/home/home_components/home_category_component.dart
@@ -8,6 +8,7 @@ import 'package:frontend/model/config/category_card_list.dart';
 import 'package:get/get.dart';
 
 class HomeCategory extends StatelessWidget {
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -64,6 +65,9 @@ class CategoryCard extends StatelessWidget {
               categoryList.indexWhere((category) => category['name'] == name);
 
           Get.to(ChallengeSearchScreen(enterSelectIndex: index + 1));
+          int index = categoryList.indexWhere((category) => category['name'] == name);
+
+          Get.to(ChallengeSearchScreen(enterSelectIndex: index+1));
         },
         child: Container(
             padding: const EdgeInsets.all(0),

--- a/frontend/lib/main/bottom_tabs/home/home_components/home_category_component.dart
+++ b/frontend/lib/main/bottom_tabs/home/home_components/home_category_component.dart
@@ -7,6 +7,7 @@ import 'package:frontend/model/config/palette.dart';
 import 'package:frontend/model/config/category_card_list.dart';
 import 'package:get/get.dart';
 
+
 class HomeCategory extends StatelessWidget {
 
   @override

--- a/frontend/lib/main/bottom_tabs/home/home_components/home_category_component.dart
+++ b/frontend/lib/main/bottom_tabs/home/home_components/home_category_component.dart
@@ -7,9 +7,7 @@ import 'package:frontend/model/config/palette.dart';
 import 'package:frontend/model/config/category_card_list.dart';
 import 'package:get/get.dart';
 
-
 class HomeCategory extends StatelessWidget {
-
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -62,11 +60,10 @@ class CategoryCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
         onTap: () {
-          print("$name 카테고리 클릭됨");
-          int index = categoryList.indexWhere((category) => category['name'] == name);
+          int index =
+              categoryList.indexWhere((category) => category['name'] == name);
 
-          Get.to(ChallengeSearchScreen(enterSelectIndex: index+1));
-
+          Get.to(ChallengeSearchScreen(enterSelectIndex: index + 1));
         },
         child: Container(
             padding: const EdgeInsets.all(0),

--- a/frontend/lib/main/bottom_tabs/home/home_components/home_category_component.dart
+++ b/frontend/lib/main/bottom_tabs/home/home_components/home_category_component.dart
@@ -66,10 +66,7 @@ class CategoryCard extends StatelessWidget {
               categoryList.indexWhere((category) => category['name'] == name);
 
           Get.to(ChallengeSearchScreen(enterSelectIndex: index + 1));
-          int index = categoryList.indexWhere((category) => category['name'] == name);
-
-          Get.to(ChallengeSearchScreen(enterSelectIndex: index+1));
-        },
+          },
         child: Container(
             padding: const EdgeInsets.all(0),
             width: 120, // Set the width of the card

--- a/frontend/lib/main/bottom_tabs/home/home_components/home_challenge_item_card.dart
+++ b/frontend/lib/main/bottom_tabs/home/home_components/home_challenge_item_card.dart
@@ -25,11 +25,13 @@ class ChallengeItemCard extends StatelessWidget {
 
     return GestureDetector(
         onTap: () {
-          if (data.isPrivate) {
-            logger.d("data == isprivate ${data.id}");
-            logger.d("${data.isPrivate}");
 
-            showDialog(
+        if (data.isPrivate) {
+            //비공개 챌린지라면, 암호코드 입력 dialog 호출
+          logger.d("home_challenge_item ) data.id? ${data.id}");
+          logger.d("home_challenge_item )data.isprivate ? ${data.isPrivate}");
+
+          showDialog(
               context: context,
               builder: (BuildContext context) {
                 return PasswordInputDialog(
@@ -38,9 +40,11 @@ class ChallengeItemCard extends StatelessWidget {
               },
             );
           } else {
-            logger.d("data != isprivate ${data.id}");
-            logger.d(data.isPrivate);
-            Get.to(() => ChallengeDetailScreen(
+            //비공개 챌린지가 아니라면, 디테일 스크린으로 이동
+          logger.d("home_challenge_item ) data.id? ${data.id}");
+          logger.d("home_challenge_item )data.isprivate? ${data.isPrivate}");
+
+          Get.to(() => ChallengeDetailScreen(
                   challengeId: data.id,
                   isFromMainScreen: true,
                 ));

--- a/frontend/lib/main/bottom_tabs/home/home_components/home_challenge_item_card.dart
+++ b/frontend/lib/main/bottom_tabs/home/home_components/home_challenge_item_card.dart
@@ -16,7 +16,7 @@ class ChallengeItemCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final screenSize = MediaQuery.of(context).size;
-    Logger logger =  Logger();
+    Logger logger = Logger();
     // 문자열을 DateTime 객체로 파싱
     DateTime date = data.startDate as DateTime;
 
@@ -26,21 +26,24 @@ class ChallengeItemCard extends StatelessWidget {
     return GestureDetector(
         onTap: () {
           if (data.isPrivate) {
-            logger.d(data.id);
+            logger.d("data == isprivate ${data.id}");
+            logger.d("${data.isPrivate}");
 
             showDialog(
               context: context,
               builder: (BuildContext context) {
-                return PasswordInputDialog(challengeId: data.id,);
+                return PasswordInputDialog(
+                  challengeId: data.id,
+                );
               },
             );
           } else {
-
-          logger.d(data.isPrivate);
+            logger.d("data != isprivate ${data.id}");
+            logger.d(data.isPrivate);
             Get.to(() => ChallengeDetailScreen(
-              challengeId: data.id,
-              isFromMainScreen: true,
-            ));
+                  challengeId: data.id,
+                  isFromMainScreen: true,
+                ));
           }
         },
         child: SizedBox(

--- a/frontend/lib/main/bottom_tabs/home/home_components/home_challenge_item_card.dart
+++ b/frontend/lib/main/bottom_tabs/home/home_components/home_challenge_item_card.dart
@@ -16,7 +16,7 @@ class ChallengeItemCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final screenSize = MediaQuery.of(context).size;
-
+    Logger logger =  Logger();
     // 문자열을 DateTime 객체로 파싱
     DateTime date = data.startDate as DateTime;
 
@@ -26,6 +26,8 @@ class ChallengeItemCard extends StatelessWidget {
     return GestureDetector(
         onTap: () {
           if (data.isPrivate) {
+            logger.d(data.id);
+
             showDialog(
               context: context,
               builder: (BuildContext context) {
@@ -33,6 +35,8 @@ class ChallengeItemCard extends StatelessWidget {
               },
             );
           } else {
+
+          logger.d(data.isPrivate);
             Get.to(() => ChallengeDetailScreen(
               challengeId: data.id,
               isFromMainScreen: true,

--- a/frontend/lib/main/bottom_tabs/home/home_components/home_challenge_recommend_box.dart
+++ b/frontend/lib/main/bottom_tabs/home/home_components/home_challenge_recommend_box.dart
@@ -46,7 +46,7 @@ class ChallengeRecommendBox extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.start,
               children: [
                 Text(
-                  "$name님 오늘은 ${randomCategory['category']} 관련 챌린지를 도전해 볼까요?",
+                  "$name님 오늘은 ${randomCategory['category']}\n관련 챌린지를 도전해 볼까요?",
                   style: const TextStyle(
                     color: Colors.white,
                     fontSize: 14,

--- a/frontend/lib/main/bottom_tabs/home/home_components/home_challenge_recommend_box.dart
+++ b/frontend/lib/main/bottom_tabs/home/home_components/home_challenge_recommend_box.dart
@@ -2,7 +2,9 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:frontend/challenge/search/challenge_search_screen.dart';
 import 'package:frontend/model/config/palette.dart';
+import 'package:get/get.dart';
 
 class ChallengeRecommendBox extends StatelessWidget {
   final String name;
@@ -16,11 +18,12 @@ class ChallengeRecommendBox extends StatelessWidget {
     {'category': '환경', 'svg_icon': 'assets/icons/category_icons/nature.svg'},
     {'category': '공부', 'svg_icon': 'assets/icons/category_icons/study.svg'}
   ];
+  int randomIndex = 0 ;
 
   Map<String, String> getRandomCategory(
       List<Map<String, String>> categoryIconList) {
     // Generate a random index
-    int randomIndex = Random().nextInt(categoryIconList.length);
+    randomIndex = Random().nextInt(categoryIconList.length);
 
     // Get the randomly selected map
     Map<String, String> randomMap = categoryIconList[randomIndex];
@@ -53,7 +56,10 @@ class ChallengeRecommendBox extends StatelessWidget {
                 ),
                 const SizedBox(height: 15),
                 ElevatedButton(
-                  onPressed: () {},
+                  onPressed: () {
+                    Get.to(ChallengeSearchScreen(enterSelectIndex: randomIndex+1));
+
+                  },
                   style: ButtonStyle(
                     shape: MaterialStateProperty.all<OutlinedBorder>(
                       RoundedRectangleBorder(

--- a/frontend/lib/main/bottom_tabs/home/home_components/privateCode_input_dialog.dart
+++ b/frontend/lib/main/bottom_tabs/home/home_components/privateCode_input_dialog.dart
@@ -48,7 +48,7 @@ class _PasswordInputDialogState extends State<PasswordInputDialog> {
         logger.d('$inputCode : ${response.data}코드 일치');
         logger.d(response.data);
         canAccess = true;
-      } else if (response.statusCode == 404) {
+      } else if (response.statusCode == 403) {
         logger.d('코드 불일치');
         logger.d(response.data);
         canAccess = false;
@@ -66,11 +66,15 @@ class _PasswordInputDialogState extends State<PasswordInputDialog> {
     _passwordController = TextEditingController();
     _confirmPasswordController = TextEditingController();
 
-    _fetchChallenge("아무거나101010101").then((value) => setState(() {
-      Get.snackbar("챌린지 생성자", "암호코드 없이 입장");
-      Get.to(() => ChallengeDetailScreen(
-          challengeId: widget.challengeId, isFromMainScreen: true));
-    })); //c챌린지 생성자인지 확인 용.
+    _fetchChallenge("아무거나101010101").then((value) {
+      if (value == true) {
+        setState(() {
+          Get.snackbar("챌린지 생성자", "암호코드 없이 입장");
+          Get.to(() => ChallengeDetailScreen(
+              challengeId: widget.challengeId, isFromMainScreen: true));
+        });
+      }
+    }); //c챌린지 생성자인지 확인 용.
   }
 
   @override

--- a/frontend/lib/main/bottom_tabs/home/home_components/privateCode_input_dialog.dart
+++ b/frontend/lib/main/bottom_tabs/home/home_components/privateCode_input_dialog.dart
@@ -25,39 +25,47 @@ class _PasswordInputDialogState extends State<PasswordInputDialog> {
   Challenge? challenge;
   bool isPossibleJoin = false;
 
-  TextStyle textStyle(double size, FontWeight weight, Color color) => TextStyle(
-      fontFamily: "Pretender",
-      fontSize: size,
-      fontWeight: weight,
-      color: color);
+  TextStyle textStyle(double size, FontWeight weight, Color color) =>
+      TextStyle(
+          fontFamily: "Pretender",
+          fontSize: size,
+          fontWeight: weight,
+          color: color);
 
-  Future<bool> _fetchChallenge(String inputCode) async {
+  Future<Map<String, dynamic>?> _checkInputCode(String inputCode) async {
     bool canAccess = false;
     SharedPreferences prefs = await SharedPreferences.getInstance();
     Dio dio = Dio();
     dio.options.headers['content-Type'] = 'application/json';
     dio.options.headers['Authorization'] =
-        'Bearer ${prefs.getString('access_token')}';
+    'Bearer ${prefs.getString('access_token')}';
+    logger.d("private_input_dialog )!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
 
     try {
       final response = await dio.get(
           '${Env.serverUrl}/challenges/${widget.challengeId}',
           queryParameters: {"code": inputCode});
 
+      logger.d("private_input_dialog ) ?????????????????????????????");
+
       if (response.statusCode == 200) {
-        logger.d('$inputCode : ${response.data}코드 일치');
-        logger.d(response.data);
+        logger.d('private_input_dialog ) $inputCode : ${response.data}코드 일치');
+        logger.d("private_input_dialog )  ${response.data}");
         canAccess = true;
+        return response.data;
       } else if (response.statusCode == 403) {
-        logger.d('코드 불일치');
+        logger.d('private_input_dialog )코드 불일치');
         logger.d(response.data);
-        canAccess = false;
+      }
+      else if (response.statusCode == 404) {
+        logger.d('private_input_dialog )Not Found');
+        logger.d(response.data);
       }
     } catch (e) {
       logger.e(e);
     }
 
-    return canAccess;
+    return null;
   }
 
   @override
@@ -66,12 +74,18 @@ class _PasswordInputDialogState extends State<PasswordInputDialog> {
     _passwordController = TextEditingController();
     _confirmPasswordController = TextEditingController();
 
-    _fetchChallenge("아무거나101010101").then((value) {
+    //아무거나 입력해봐서 통과되면 챌린지 생성자
+    _checkInputCode("아무거나101010101").then((value) {
+      logger.d("dialog initState() : $value");
       if (value == true) {
         setState(() {
           Get.snackbar("챌린지 생성자", "암호코드 없이 입장");
-          Get.to(() => ChallengeDetailScreen(
-              challengeId: widget.challengeId, isFromMainScreen: true));
+          Get.to(() =>
+              ChallengeDetailScreen(
+                  challengeId: widget.challengeId,
+                  isFromMainScreen: true,
+                  isFromPrivateCodeDialog: true,
+                  challengeData: value));
         });
       }
     }); //c챌린지 생성자인지 확인 용.
@@ -116,18 +130,26 @@ class _PasswordInputDialogState extends State<PasswordInputDialog> {
           onPressed: () async {
             String password = _passwordController.text;
 
-            if (await _fetchChallenge(password)) {
-              // Passwords match, handle confirmation
-              Get.to(() => ChallengeDetailScreen(
-                  challengeId: widget.challengeId, isFromMainScreen: true));
-            } else {
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(
-                  content: Text('비공개 암호가 일치하지 않습니다'),
-                  duration: Duration(seconds: 2),
-                ),
-              );
-            }
+            _checkInputCode(password).then(
+                    (value) {
+                  if (value != null) {
+                    Get.to(() =>
+                        ChallengeDetailScreen(
+                            challengeId: widget.challengeId,
+                            isFromMainScreen: true,
+                            isFromPrivateCodeDialog : true,
+                            challengeData: value));
+                  }
+                  else {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('비공개 암호가 일치하지 않습니다'),
+                        duration: Duration(seconds: 2),
+                      ),
+                    );
+                  }
+                }
+            );
           },
           child: Text('확인',
               style: textStyle(13.0, FontWeight.w500, Palette.purPle400)),

--- a/frontend/lib/main/bottom_tabs/mypage/widget/category_bottom_sheet.dart
+++ b/frontend/lib/main/bottom_tabs/mypage/widget/category_bottom_sheet.dart
@@ -85,6 +85,12 @@ class _CategoryBottomSheetState extends State<CategoryBottomSheet> {
       if (response.statusCode == 200) {
         final responseData = response.data is String ? jsonDecode(response.data) : response.data;
         logger.d("responseData : $responseData");
+
+
+        // UserController 업데이트
+        userController.updateCategories(categories);
+
+
         return responseData['id']; // 적절한 키로 값을 추출하여 반환
       } else {
         throw Exception('Failed to post categories');

--- a/frontend/lib/main/bottom_tabs/mypage/widget/mypage_user_inform.dart
+++ b/frontend/lib/main/bottom_tabs/mypage/widget/mypage_user_inform.dart
@@ -38,6 +38,7 @@ class UserInformation extends StatelessWidget {
                 const SizedBox(height: 4),
                 if (categoryList.isNotEmpty)
                   Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       const Text(
                         "루티너님의 관심사는",

--- a/frontend/lib/model/config/category_card_list.dart
+++ b/frontend/lib/model/config/category_card_list.dart
@@ -1,0 +1,34 @@
+import 'dart:ui';
+
+final List<Map<String, dynamic>> categoryList = [
+  {
+    "name": "운동",
+    "memo": "튼튼한 몸을 위하여!",
+    "icons": "assets/icons/category_icons/exercise.svg",
+    "color": const Color(0xffEEE9FD),
+  },
+  {
+    "name": "식습관",
+    "memo": "골고루 건강하게!",
+    "icons": "assets/icons/category_icons/eating.svg",
+    "color": const Color(0xffFFDFDF),
+  },
+  {
+    "name": "취미",
+    "memo": "더 즐거운 삶을 위해!",
+    "icons": "assets/icons/category_icons/hobby.svg",
+    "color": const Color(0xffFFD0A3),
+  },
+  {
+    "name": "환경",
+    "memo": "깨끗한 환경에서!",
+    "icons": "assets/icons/category_icons/nature.svg",
+    "color": const Color(0xffDAF2CB),
+  },
+  {
+    "name": "공부",
+    "memo": "지적인 나를 위해!",
+    "icons": "assets/icons/category_icons/study.svg",
+    "color": const Color(0xffD4E0FF),
+  }
+];

--- a/frontend/lib/model/data/challenge/challenge_category.dart
+++ b/frontend/lib/model/data/challenge/challenge_category.dart
@@ -1,3 +1,5 @@
+import 'package:logger/logger.dart';
+
 enum ChallengeCategory {
   exercise('운동'),
   eating('식습관'),
@@ -10,7 +12,13 @@ enum ChallengeCategory {
 
   // JSON에서 객체로 변환
   factory ChallengeCategory.fromJson(String name) {
-    return ChallengeCategory.values.firstWhere((e) => e.name == name);
+    try {
+      return ChallengeCategory.values.firstWhere((e) => e.name == name);
+    } catch (e) {
+      // Log the error and return a default value or handle it appropriately
+      Logger().e('Invalid category name: $name');
+      throw Exception('Invalid category name: $name');
+    }
   }
 
   // 객체에서 JSON으로 변환


### PR DESCRIPTION
## 개요 :mag:

비공개 챌린지 ) 암호코드 입력 후 디테일 스크린
공개 챌린지 ) 바로 디테일 스크린

백엔드 연동 완료했습니다.

### 연관된 이슈

#139 

## 작업사항 :memo:

`암호코드 입력하면서 챌린지 정보를 조회하는데, 디테일스크린에서 암호코드없이 한번 더 조회하게 되면서 에러가 살생했습니다. 
=> 암호코드 입력시 조회한 데이터를 디테일 스크린으로 전달하면서 중복 조회를 방지하였고, 에러가 나지 않습니다.`

### 스크린샷 (선택)

## 테스트 방법

`리뷰하는 사람이 어떻게 테스트할 수 있을지 간략히 써주세요.`

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
