### PR TITLE
[be/fix] ChallengeSimpleList를 id 기준 내림차순으로 전송 (#159)

### DIFF
--- a/backend/src/main/java/km/cd/backend/challenge/repository/ChallengeCustomRepositoryImpl.java
+++ b/backend/src/main/java/km/cd/backend/challenge/repository/ChallengeCustomRepositoryImpl.java
@@ -17,34 +17,35 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository {
 
-  private final JPAQueryFactory queryFactory;
+    private final JPAQueryFactory queryFactory;
 
-  @Override
-  public List<Challenge> findByChallengeWithFilterAndPaging(Long cursorId, int size, ChallengeFilter filter) {
-    QChallenge challenge = QChallenge.challenge;
-    BooleanExpression predicate = challenge.isNotNull();
+    @Override
+    public List<Challenge> findByChallengeWithFilterAndPaging(Long cursorId, int size, ChallengeFilter filter) {
+        QChallenge challenge = QChallenge.challenge;
+        BooleanExpression predicate = challenge.isNotNull();
 
-    if (cursorId != 0) {
-      predicate = challenge.id.lt(cursorId);
+        if (cursorId != 0) {
+            predicate = challenge.id.lt(cursorId);
+        }
+
+        if (StringUtils.hasText(filter.name())) {
+            predicate = challenge.challengeName.startsWith(filter.name());
+        }
+
+        if (filter.isPrivate() != null) {
+            predicate = predicate.and(challenge.isPrivate.eq(filter.isPrivate()));
+        }
+
+        if (filter.category() != null) {
+            predicate = predicate.and(challenge.challengeCategory.eq(filter.category()));
+        }
+
+        return queryFactory
+                .selectFrom(challenge)
+                .where(predicate)
+                .limit(size)
+                .orderBy(challenge.id.desc())
+                .fetch();
     }
 
-    if (StringUtils.hasText(filter.name())) {
-      predicate = challenge.challengeName.startsWith(filter.name());
-    }
-
-    if (filter.isPrivate() != null) {
-      predicate = predicate.and(challenge.isPrivate.eq(filter.isPrivate()));
-    }
-
-    if (filter.category() != null) {
-      predicate = predicate.and(challenge.challengeCategory.eq(filter.category()));
-    }
-
-    return queryFactory
-      .selectFrom(challenge)
-      .where(predicate)
-      .limit(size)
-      .fetch();
-  }
-  
 }


### PR DESCRIPTION
## 개요 :mag:

챌린지 목록을 cursor 방식으로 받아오는 과정에서 계속 조회가 되서 백엔드 부분을 수정했습니다.

### 연관된 이슈

Fixed #159 

## 작업사항 :memo:

챌린지 목록을 id 기준 내림차순으로 전송하여 해당 id 기준 밑으로만 조회가 되도록 수정했습니다.

### 스크린샷 (선택)

## 테스트 방법

`리뷰하는 사람이 어떻게 테스트할 수 있을지 간략히 써주세요.`

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
